### PR TITLE
ride 정책 상태 카드 추가

### DIFF
--- a/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
@@ -4,6 +4,8 @@ import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -15,15 +17,26 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import com.bikeprojectminji.bikefront.ridepolicy.HttpRidePolicyEvaluationGateway;
+import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyEvaluationGateway;
+import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyUiMapper;
+import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyUiModel;
+
+import java.util.List;
 
 public class RideEntryActivity extends AppCompatActivity {
 
+    private static final String EXTRA_COURSE_ID = "extra_course_id";
     private static final String EXTRA_TITLE = "extra_title";
     private static final String EXTRA_DISTANCE_TEXT = "extra_distance_text";
     private static final String EXTRA_DURATION_TEXT = "extra_duration_text";
     private static final String KEY_PERMISSION_STATE = "key_permission_state";
+    private static final String KEY_RIDE_PHASE = "key_ride_phase";
+    private static final String PHASE_PRE_START = "PRE_START";
+    private static final String PHASE_ACTIVE = "ACTIVE";
 
     private enum PermissionUiState {
         REQUESTING,
@@ -36,19 +49,28 @@ public class RideEntryActivity extends AppCompatActivity {
     private TextView ridePermissionMessageTextView;
     private TextView ridePermissionBlockedFeaturesTextView;
     private TextView rideFlowStatusTextView;
+    private TextView ridePolicyBannerTextView;
+    private TextView ridePolicyStateTextView;
+    private TextView ridePolicyMessageTextView;
     private Button ridePermissionRetryButton;
     private Button ridePermissionSettingsButton;
 
     private PermissionUiState permissionUiState = PermissionUiState.REQUESTING;
     private boolean openedSettings;
+    private long courseId;
+    private String ridePhase = PHASE_PRE_START;
+
+    private final RidePolicyEvaluationGateway ridePolicyEvaluationGateway = new HttpRidePolicyEvaluationGateway();
+    private final RidePolicyUiMapper ridePolicyUiMapper = new RidePolicyUiMapper();
 
     private final ActivityResultLauncher<String> locationPermissionLauncher = registerForActivityResult(
             new ActivityResultContracts.RequestPermission(),
             this::handleLocationPermissionResult
     );
 
-    public static Intent newIntent(Context context, String title, String distanceText, String durationText) {
+    public static Intent newIntent(Context context, long courseId, String title, String distanceText, String durationText) {
         Intent intent = new Intent(context, RideEntryActivity.class);
+        intent.putExtra(EXTRA_COURSE_ID, courseId);
         intent.putExtra(EXTRA_TITLE, title);
         intent.putExtra(EXTRA_DISTANCE_TEXT, distanceText);
         intent.putExtra(EXTRA_DURATION_TEXT, durationText);
@@ -66,10 +88,14 @@ public class RideEntryActivity extends AppCompatActivity {
         ridePermissionMessageTextView = findViewById(R.id.ridePermissionMessageTextView);
         ridePermissionBlockedFeaturesTextView = findViewById(R.id.ridePermissionBlockedFeaturesTextView);
         rideFlowStatusTextView = findViewById(R.id.rideFlowStatusTextView);
+        ridePolicyBannerTextView = findViewById(R.id.ridePolicyBannerTextView);
+        ridePolicyStateTextView = findViewById(R.id.ridePolicyStateTextView);
+        ridePolicyMessageTextView = findViewById(R.id.ridePolicyMessageTextView);
         ridePermissionRetryButton = findViewById(R.id.ridePermissionRetryButton);
         ridePermissionSettingsButton = findViewById(R.id.ridePermissionSettingsButton);
 
         Intent intent = getIntent();
+        courseId = intent.getLongExtra(EXTRA_COURSE_ID, -1L);
         titleTextView.setText(intent.getStringExtra(EXTRA_TITLE));
         distanceTextView.setText(intent.getStringExtra(EXTRA_DISTANCE_TEXT));
         durationTextView.setText(intent.getStringExtra(EXTRA_DURATION_TEXT));
@@ -80,6 +106,7 @@ public class RideEntryActivity extends AppCompatActivity {
         if (savedInstanceState != null) {
             String savedState = savedInstanceState.getString(KEY_PERMISSION_STATE, PermissionUiState.REQUESTING.name());
             permissionUiState = PermissionUiState.valueOf(savedState);
+            ridePhase = savedInstanceState.getString(KEY_RIDE_PHASE, PHASE_PRE_START);
             if (hasLocationPermission()) {
                 resumeRideFlow();
             } else if (permissionUiState == PermissionUiState.REQUESTING) {
@@ -88,6 +115,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 renderPermissionState(permissionUiState);
             }
         } else {
+            renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
             requestLocationPermission();
         }
     }
@@ -110,6 +138,7 @@ public class RideEntryActivity extends AppCompatActivity {
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(KEY_PERMISSION_STATE, permissionUiState.name());
+        outState.putString(KEY_RIDE_PHASE, ridePhase);
     }
 
     private void requestLocationPermission() {
@@ -138,6 +167,7 @@ public class RideEntryActivity extends AppCompatActivity {
 
     private void resumeRideFlow() {
         renderPermissionState(PermissionUiState.GRANTED);
+        refreshRidePolicy();
     }
 
     private void renderPermissionState(PermissionUiState newState) {
@@ -151,6 +181,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 ridePermissionRetryButton.setVisibility(View.VISIBLE);
                 ridePermissionSettingsButton.setVisibility(View.GONE);
                 rideFlowStatusTextView.setText(R.string.ride_permission_resuming_message);
+                renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
                 break;
             case NEED_PERMISSION:
                 ridePermissionMessageTextView.setText(R.string.ride_permission_message);
@@ -159,6 +190,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 ridePermissionRetryButton.setVisibility(View.VISIBLE);
                 ridePermissionSettingsButton.setVisibility(View.VISIBLE);
                 rideFlowStatusTextView.setText(R.string.ride_placeholder_message);
+                renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_permission_blocked_message));
                 break;
             case DENIED:
                 ridePermissionMessageTextView.setText(R.string.ride_permission_message);
@@ -167,6 +199,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 ridePermissionRetryButton.setVisibility(View.VISIBLE);
                 ridePermissionSettingsButton.setVisibility(View.VISIBLE);
                 rideFlowStatusTextView.setText(R.string.ride_placeholder_message);
+                renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_permission_blocked_message));
                 break;
             case SETTINGS_REQUIRED:
                 ridePermissionMessageTextView.setText(R.string.ride_permission_settings_message);
@@ -175,6 +208,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 ridePermissionRetryButton.setVisibility(View.VISIBLE);
                 ridePermissionSettingsButton.setVisibility(View.VISIBLE);
                 rideFlowStatusTextView.setText(R.string.ride_placeholder_message);
+                renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_permission_blocked_message));
                 break;
             case GRANTED:
                 ridePermissionMessageTextView.setText(R.string.ride_permission_resuming_message);
@@ -183,6 +217,113 @@ public class RideEntryActivity extends AppCompatActivity {
                 ridePermissionSettingsButton.setVisibility(View.GONE);
                 rideFlowStatusTextView.setText(R.string.ride_location_status_resumed);
                 break;
+        }
+    }
+
+    private void refreshRidePolicy() {
+        if (courseId <= 0) {
+            renderPolicyError(getString(R.string.ride_policy_missing_course_message));
+            return;
+        }
+
+        Location location = resolveBestLastKnownLocation();
+        if (location == null) {
+            renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
+            return;
+        }
+
+        evaluateRidePolicy(location, ridePhase);
+    }
+
+    private void evaluateRidePolicy(Location location, String phase) {
+        renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
+        ridePolicyEvaluationGateway.evaluate(courseId, phase, location, new RidePolicyEvaluationGateway.Callback() {
+            @Override
+            public void onSuccess(RidePolicyEvaluationGateway.EvaluationResult result) {
+                if (isFinishing() || isDestroyed()) {
+                    return;
+                }
+
+                if (PHASE_PRE_START.equals(phase) && "ELIGIBLE".equals(result.getStartGate().getStatus())) {
+                    ridePhase = PHASE_ACTIVE;
+                    evaluateRidePolicy(location, PHASE_ACTIVE);
+                    return;
+                }
+
+                ridePhase = result.getPhase();
+                renderPolicyResult(ridePolicyUiMapper.map(result));
+            }
+
+            @Override
+            public void onFailure(String message) {
+                if (isFinishing() || isDestroyed()) {
+                    return;
+                }
+
+                renderPolicyError(message);
+            }
+        });
+    }
+
+    private Location resolveBestLastKnownLocation() {
+        try {
+            LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+            if (locationManager == null) {
+                return null;
+            }
+
+            List<String> providers = locationManager.getProviders(true);
+            Location latestLocation = null;
+            for (String provider : providers) {
+                Location candidate = locationManager.getLastKnownLocation(provider);
+                if (candidate == null) {
+                    continue;
+                }
+                if (latestLocation == null || candidate.getTime() > latestLocation.getTime()) {
+                    latestLocation = candidate;
+                }
+            }
+
+            return latestLocation;
+        } catch (SecurityException exception) {
+            renderPolicyError(getString(R.string.ride_policy_location_error_message));
+            return null;
+        }
+    }
+
+    private void renderPolicyPending(String stateLabel, String message) {
+        ridePolicyStateTextView.setText(stateLabel);
+        ridePolicyStateTextView.setTextColor(ContextCompat.getColor(this, R.color.info_text));
+        ridePolicyMessageTextView.setText(message);
+        ridePolicyBannerTextView.setVisibility(View.GONE);
+        rideFlowStatusTextView.setVisibility(View.VISIBLE);
+        rideFlowStatusTextView.setText(message);
+    }
+
+    private void renderPolicyError(String message) {
+        ridePolicyStateTextView.setText(R.string.ride_policy_error_label);
+        ridePolicyStateTextView.setTextColor(ContextCompat.getColor(this, R.color.error_text));
+        ridePolicyMessageTextView.setText(message);
+        ridePolicyBannerTextView.setVisibility(View.GONE);
+        rideFlowStatusTextView.setVisibility(View.VISIBLE);
+        rideFlowStatusTextView.setText(message);
+    }
+
+    private void renderPolicyResult(RidePolicyUiModel uiModel) {
+        ridePolicyStateTextView.setText(uiModel.getStateLabel());
+        ridePolicyStateTextView.setTextColor(ContextCompat.getColor(this, uiModel.getStateTextColorResId()));
+        ridePolicyMessageTextView.setText(uiModel.getMessage());
+
+        if (uiModel.isShowBanner()) {
+            ridePolicyBannerTextView.setText(uiModel.getBannerMessage());
+            ridePolicyBannerTextView.setTextColor(ContextCompat.getColor(this, uiModel.getBannerTextColorResId()));
+            ridePolicyBannerTextView.setBackgroundColor(ContextCompat.getColor(this, uiModel.getBannerBackgroundColorResId()));
+            ridePolicyBannerTextView.setVisibility(View.VISIBLE);
+            rideFlowStatusTextView.setVisibility(View.GONE);
+        } else {
+            ridePolicyBannerTextView.setVisibility(View.GONE);
+            rideFlowStatusTextView.setVisibility(View.VISIBLE);
+            rideFlowStatusTextView.setText(uiModel.getMessage());
         }
     }
 

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/HttpRidePolicyEvaluationGateway.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/HttpRidePolicyEvaluationGateway.java
@@ -1,0 +1,147 @@
+package com.bikeprojectminji.bikefront.ridepolicy;
+
+import android.location.Location;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.bikeprojectminji.bikefront.config.AppConfig;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class HttpRidePolicyEvaluationGateway implements RidePolicyEvaluationGateway {
+
+    private static final String FALLBACK_ERROR_MESSAGE = "주행 정책을 확인하지 못했습니다. 다시 시도해 주세요.";
+
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void evaluate(long courseId, String phase, Location location, Callback callback) {
+        executorService.execute(() -> {
+            try {
+                EvaluationResult result = requestEvaluation(courseId, phase, location);
+                mainHandler.post(() -> callback.onSuccess(result));
+            } catch (Exception exception) {
+                String message = exception.getMessage();
+                mainHandler.post(() -> callback.onFailure(resolveErrorMessage(message)));
+            }
+        });
+    }
+
+    private EvaluationResult requestEvaluation(long courseId, String phase, Location location) throws Exception {
+        HttpURLConnection connection = null;
+
+        try {
+            URL url = new URL(AppConfig.API_BASE_URL + "/api/v1/courses/" + courseId + "/ride-policy/evaluate");
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setConnectTimeout(AppConfig.CONNECT_TIMEOUT_MS);
+            connection.setReadTimeout(AppConfig.READ_TIMEOUT_MS);
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            connection.getOutputStream().write(buildRequestBody(phase, location).getBytes(StandardCharsets.UTF_8));
+
+            int responseCode = connection.getResponseCode();
+            InputStream inputStream = responseCode >= HttpURLConnection.HTTP_BAD_REQUEST
+                    ? connection.getErrorStream()
+                    : connection.getInputStream();
+
+            if (inputStream == null) {
+                throw new Exception(FALLBACK_ERROR_MESSAGE);
+            }
+
+            String responseBody = readBody(inputStream);
+            JSONObject root = new JSONObject(responseBody);
+
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new Exception(root.optString("message", FALLBACK_ERROR_MESSAGE));
+            }
+
+            JSONObject data = root.optJSONObject("data");
+            if (data == null) {
+                throw new Exception(FALLBACK_ERROR_MESSAGE);
+            }
+
+            JSONObject startGate = data.optJSONObject("startGate");
+            JSONObject offRoute = data.optJSONObject("offRoute");
+
+            return new EvaluationResult(
+                    data.optString("phase", phase),
+                    parseGate(startGate),
+                    parseGate(offRoute),
+                    data.optString("overallState", "UNDETERMINED"),
+                    data.optString("defaultMessage", FALLBACK_ERROR_MESSAGE)
+            );
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private String buildRequestBody(String phase, Location location) throws Exception {
+        JSONObject payload = new JSONObject();
+        JSONObject locationJson = new JSONObject();
+
+        payload.put("phase", phase);
+        locationJson.put("lat", location.getLatitude());
+        locationJson.put("lon", location.getLongitude());
+        locationJson.put("accuracyM", location.hasAccuracy() ? location.getAccuracy() : 100d);
+        locationJson.put("capturedAt", toOffsetDateTime(location));
+        payload.put("location", locationJson);
+
+        return payload.toString();
+    }
+
+    private String toOffsetDateTime(Location location) {
+        long capturedAtMillis = location.getTime() > 0 ? location.getTime() : System.currentTimeMillis();
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(capturedAtMillis), ZoneId.systemDefault())
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    private GateResult parseGate(JSONObject gate) {
+        if (gate == null) {
+            return new GateResult("UNDETERMINED", "UNKNOWN_GATE");
+        }
+
+        return new GateResult(
+                gate.optString("status", "UNDETERMINED"),
+                gate.optString("reasonCode", "UNKNOWN_REASON")
+        );
+    }
+
+    private String readBody(InputStream inputStream) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+            builder.append(line);
+        }
+
+        reader.close();
+        return builder.toString();
+    }
+
+    private String resolveErrorMessage(String message) {
+        if (message == null || message.isBlank()) {
+            return FALLBACK_ERROR_MESSAGE;
+        }
+
+        return message;
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/RidePolicyEvaluationGateway.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/RidePolicyEvaluationGateway.java
@@ -1,0 +1,74 @@
+package com.bikeprojectminji.bikefront.ridepolicy;
+
+import android.location.Location;
+
+public interface RidePolicyEvaluationGateway {
+
+    final class GateResult {
+        private final String status;
+        private final String reasonCode;
+
+        public GateResult(String status, String reasonCode) {
+            this.status = status;
+            this.reasonCode = reasonCode;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public String getReasonCode() {
+            return reasonCode;
+        }
+    }
+
+    final class EvaluationResult {
+        private final String phase;
+        private final GateResult startGate;
+        private final GateResult offRoute;
+        private final String overallState;
+        private final String defaultMessage;
+
+        public EvaluationResult(
+                String phase,
+                GateResult startGate,
+                GateResult offRoute,
+                String overallState,
+                String defaultMessage
+        ) {
+            this.phase = phase;
+            this.startGate = startGate;
+            this.offRoute = offRoute;
+            this.overallState = overallState;
+            this.defaultMessage = defaultMessage;
+        }
+
+        public String getPhase() {
+            return phase;
+        }
+
+        public GateResult getStartGate() {
+            return startGate;
+        }
+
+        public GateResult getOffRoute() {
+            return offRoute;
+        }
+
+        public String getOverallState() {
+            return overallState;
+        }
+
+        public String getDefaultMessage() {
+            return defaultMessage;
+        }
+    }
+
+    interface Callback {
+        void onSuccess(EvaluationResult result);
+
+        void onFailure(String message);
+    }
+
+    void evaluate(long courseId, String phase, Location location, Callback callback);
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/RidePolicyUiMapper.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/RidePolicyUiMapper.java
@@ -1,0 +1,138 @@
+package com.bikeprojectminji.bikefront.ridepolicy;
+
+import com.bikeprojectminji.bikefront.R;
+
+public class RidePolicyUiMapper {
+
+    public RidePolicyUiModel map(RidePolicyEvaluationGateway.EvaluationResult result) {
+        String phase = result.getPhase();
+        String message = resolveMessage(result);
+
+        if ("ACTIVE".equals(phase)) {
+            return mapActive(result, message);
+        }
+
+        return mapPreStart(result, message);
+    }
+
+    private RidePolicyUiModel mapPreStart(RidePolicyEvaluationGateway.EvaluationResult result, String message) {
+        String status = result.getStartGate().getStatus();
+
+        if ("ELIGIBLE".equals(status)) {
+            return new RidePolicyUiModel(
+                    "주행 가능",
+                    message,
+                    false,
+                    "",
+                    R.color.success_text,
+                    R.color.banner_warning_background,
+                    R.color.error_text
+            );
+        }
+
+        if ("BLOCKED".equals(status)) {
+            return new RidePolicyUiModel(
+                    "시작 위치 확인 필요",
+                    message,
+                    true,
+                    message,
+                    R.color.error_text,
+                    R.color.banner_warning_background,
+                    R.color.error_text
+            );
+        }
+
+        return new RidePolicyUiModel(
+                "판단 보류",
+                message,
+                false,
+                "",
+                R.color.info_text,
+                R.color.banner_warning_background,
+                R.color.error_text
+        );
+    }
+
+    private RidePolicyUiModel mapActive(RidePolicyEvaluationGateway.EvaluationResult result, String message) {
+        String status = result.getOffRoute().getStatus();
+
+        if ("ON_ROUTE".equals(status)) {
+            return new RidePolicyUiModel(
+                    "주행 중",
+                    message,
+                    false,
+                    "",
+                    R.color.success_text,
+                    R.color.banner_warning_background,
+                    R.color.error_text
+            );
+        }
+
+        if ("WARNING".equals(status)) {
+            return new RidePolicyUiModel(
+                    "경로 이탈 경고",
+                    message,
+                    true,
+                    message,
+                    R.color.error_text,
+                    R.color.banner_warning_background,
+                    R.color.error_text
+            );
+        }
+
+        return new RidePolicyUiModel(
+                "판단 보류",
+                message,
+                false,
+                "",
+                R.color.info_text,
+                R.color.banner_warning_background,
+                R.color.error_text
+        );
+    }
+
+    private String resolveMessage(RidePolicyEvaluationGateway.EvaluationResult result) {
+        String defaultMessage = result.getDefaultMessage();
+        if (defaultMessage != null && !defaultMessage.isBlank()) {
+            return defaultMessage;
+        }
+
+        if ("ACTIVE".equals(result.getPhase())) {
+            return fallbackForReasonCode(result.getOffRoute().getReasonCode(), true);
+        }
+
+        return fallbackForReasonCode(result.getStartGate().getReasonCode(), false);
+    }
+
+    private String fallbackForReasonCode(String reasonCode, boolean activePhase) {
+        if ("LOCATION_LOW_ACCURACY".equals(reasonCode)) {
+            return activePhase
+                    ? "현재 위치 정확도가 낮아 경로 이탈 여부를 판단하기 어렵습니다."
+                    : "위치 정확도가 낮아 시작 가능 여부를 판단하기 어렵습니다.";
+        }
+        if ("LOCATION_STALE".equals(reasonCode)) {
+            return activePhase
+                    ? "위치 정보가 오래되어 경로 이탈 여부를 판단하기 어렵습니다."
+                    : "위치 정보가 오래되어 시작 가능 여부를 판단하기 어렵습니다.";
+        }
+        if ("TOO_FAR_FROM_COURSE".equals(reasonCode)) {
+            return "경로 인근에서 시작해야 합니다. 현재 위치가 선택한 코스와 너무 멉니다.";
+        }
+        if ("WITHIN_START_OR_ROUTE".equals(reasonCode)) {
+            return "주행을 시작할 수 있습니다.";
+        }
+        if ("WITHIN_ROUTE_THRESHOLD".equals(reasonCode) || "ALREADY_ACTIVE".equals(reasonCode)) {
+            return "현재 코스를 따라 주행 중입니다.";
+        }
+        if ("OFF_ROUTE_THRESHOLD_EXCEEDED".equals(reasonCode)) {
+            return "경로를 벗어났습니다. 코스 라인으로 복귀하세요.";
+        }
+        if ("COURSE_PATH_INVALID".equals(reasonCode)) {
+            return "코스 경로 정보를 확인할 수 없어 이탈 여부를 판단하기 어렵습니다.";
+        }
+
+        return activePhase
+                ? "현재 위치를 다시 확인해 주세요."
+                : "위치 정보를 다시 확인해 주세요.";
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/RidePolicyUiModel.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ridepolicy/RidePolicyUiModel.java
@@ -1,0 +1,58 @@
+package com.bikeprojectminji.bikefront.ridepolicy;
+
+public class RidePolicyUiModel {
+
+    private final String stateLabel;
+    private final String message;
+    private final boolean showBanner;
+    private final String bannerMessage;
+    private final int stateTextColorResId;
+    private final int bannerBackgroundColorResId;
+    private final int bannerTextColorResId;
+
+    public RidePolicyUiModel(
+            String stateLabel,
+            String message,
+            boolean showBanner,
+            String bannerMessage,
+            int stateTextColorResId,
+            int bannerBackgroundColorResId,
+            int bannerTextColorResId
+    ) {
+        this.stateLabel = stateLabel;
+        this.message = message;
+        this.showBanner = showBanner;
+        this.bannerMessage = bannerMessage;
+        this.stateTextColorResId = stateTextColorResId;
+        this.bannerBackgroundColorResId = bannerBackgroundColorResId;
+        this.bannerTextColorResId = bannerTextColorResId;
+    }
+
+    public String getStateLabel() {
+        return stateLabel;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isShowBanner() {
+        return showBanner;
+    }
+
+    public String getBannerMessage() {
+        return bannerMessage;
+    }
+
+    public int getStateTextColorResId() {
+        return stateTextColorResId;
+    }
+
+    public int getBannerBackgroundColorResId() {
+        return bannerBackgroundColorResId;
+    }
+
+    public int getBannerTextColorResId() {
+        return bannerTextColorResId;
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/sheet/FeaturedCourseConfirmDialogFragment.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/sheet/FeaturedCourseConfirmDialogFragment.java
@@ -97,6 +97,7 @@ public class FeaturedCourseConfirmDialogFragment extends DialogFragment {
             startButton.setEnabled(false);
             Intent intent = RideEntryActivity.newIntent(
                     requireContext(),
+                    courseDetail.getId(),
                     courseDetail.getTitle(),
                     formatDistance(courseDetail.getDistanceKm()),
                     getString(R.string.featured_course_duration_format, courseDetail.getEstimatedDurationMin())

--- a/app/src/main/res/layout/activity_ride_entry.xml
+++ b/app/src/main/res/layout/activity_ride_entry.xml
@@ -127,6 +127,61 @@
     </LinearLayout>
 
     <TextView
+        android:id="@+id/ridePolicyBannerTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/section_spacing"
+        android:background="@color/banner_warning_background"
+        android:padding="@dimen/card_padding"
+        android:textColor="@color/error_text"
+        android:textSize="@dimen/text_body"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ridePermissionContainer" />
+
+    <LinearLayout
+        android:id="@+id/ridePolicyContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/section_spacing"
+        android:background="@drawable/bg_card_surface"
+        android:orientation="vertical"
+        android:padding="@dimen/card_padding"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ridePolicyBannerTextView">
+
+        <TextView
+            android:id="@+id/ridePolicyTitleTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/ride_policy_card_title"
+            android:textColor="@color/text_primary"
+            android:textSize="@dimen/text_body_large"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/ridePolicyStateTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/s_spacing"
+            android:text="@string/ride_policy_pending_label"
+            android:textColor="@color/info_text"
+            android:textSize="@dimen/text_body_large"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/ridePolicyMessageTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/xs_spacing"
+            android:text="@string/ride_policy_loading_message"
+            android:textColor="@color/text_secondary"
+            android:textSize="@dimen/text_body" />
+    </LinearLayout>
+
+    <TextView
         android:id="@+id/rideFlowStatusTextView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -136,6 +191,6 @@
         android:textSize="@dimen/text_body"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ridePermissionContainer" />
+        app:layout_constraintTop_toBottomOf="@id/ridePolicyContainer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,7 @@
     <color name="text_secondary">#FF4B5563</color>
     <color name="stroke_light">#FFD1D5DB</color>
     <color name="error_text">#FFB42318</color>
+    <color name="success_text">#FF027A48</color>
+    <color name="info_text">#FF175CD3</color>
+    <color name="banner_warning_background">#FFFEE4E2</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,11 @@
     <string name="ride_location_status_title">위치 기반 기능 상태</string>
     <string name="ride_location_status_blocked">현재 위치 표시, 속도 계산, 주행 정책 판단, 이탈 경고, 위치 기반 날씨 조회는 권한 허용 전까지 차단됩니다.</string>
     <string name="ride_location_status_resumed">위치 권한이 허용되어 ride 흐름을 이어갈 수 있습니다.</string>
+    <string name="ride_policy_card_title">주행 정책</string>
+    <string name="ride_policy_pending_label">판단 보류</string>
+    <string name="ride_policy_error_label">정책 확인 실패</string>
+    <string name="ride_policy_loading_message">현재 위치를 확인하는 중입니다.</string>
+    <string name="ride_policy_permission_blocked_message">위치 권한 허용 전까지 주행정책을 확인할 수 없습니다.</string>
+    <string name="ride_policy_location_error_message">위치 정보를 읽지 못해 주행 정책을 확인할 수 없습니다.</string>
+    <string name="ride_policy_missing_course_message">코스 정보를 확인할 수 없어 주행 정책을 평가할 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
## 작업 목적
- ride 화면에서 주행 정책 상태를 카드와 안내 문구로 표시합니다.

## 변경 내용
- RideEntryActivity에 주행 정책 카드와 우선순위 메시지 영역을 추가했습니다.
- 위치 권한 허용 후 현재 위치를 읽어 POST /api/v1/courses/{courseId}/ride-policy/evaluate를 호출합니다.
- PRE_START에서 ELIGIBLE가 나오면 같은 위치 기준으로 ACTIVE 평가를 다시 수행하도록 연결했습니다.
- 정책 응답의 status / reasonCode / defaultMessage를 그대로 소비하는 idepolicy/ 패키지를 추가했습니다.
- 빌드 과정에서 필요한 courseId 전달과 정책 UI 리소스를 함께 보강했습니다.

## 확인 방법
- gradlew.bat :app:compileDebugJavaWithJavac
- gradlew.bat :app:assembleDebug
- 위치 권한 허용 후 ride 화면에서 정책 카드/문구가 갱신되는 코드 경로 확인

## 문서 정합성
- DOCS/15_기능명세/frontend-mobile/ride_화면_UX_정책_및_요구사항.md
- DOCS/15_기능명세/backend/주행_정책_백엔드_계약_및_요구사항.md
- 프론트는 거리 재계산 없이 defaultMessage, status, easonCode를 소비합니다.

## self-review 결과
- 판정: OK with comments
- 머지 가능 여부: 보완 후 가능
- 확인한 핵심: compile/assemble은 통과했지만, 실제 기기/에뮬레이터에서 위치 provider가 없는 경우에는 정책이 판단 보류로 머무를 수 있습니다.
- 이슈: closes #6