### PR TITLE
ride 속도 카드 추가

### DIFF
--- a/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
@@ -27,6 +27,8 @@ import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyUiMapper;
 import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyUiModel;
 import com.bikeprojectminji.bikefront.ridemap.CourseRoutePointsGateway;
 import com.bikeprojectminji.bikefront.ridemap.HttpCourseRoutePointsGateway;
+import com.bikeprojectminji.bikefront.speed.RideSpeedFormatter;
+import com.bikeprojectminji.bikefront.speed.RideSpeedUiState;
 
 import org.maplibre.android.MapLibre;
 import org.maplibre.android.camera.CameraPosition;
@@ -78,6 +80,8 @@ public class RideEntryActivity extends AppCompatActivity {
     private TextView rideFlowStatusTextView;
     private TextView rideMapStatusTextView;
     private TextView ridePolicyBannerTextView;
+    private TextView rideSpeedValueTextView;
+    private TextView rideSpeedMessageTextView;
     private TextView ridePolicyStateTextView;
     private TextView ridePolicyMessageTextView;
     private Button rideMyLocationButton;
@@ -94,6 +98,7 @@ public class RideEntryActivity extends AppCompatActivity {
     private boolean hasCenteredOnRoute;
     private boolean hasCenteredOnRouteWithLocation;
     private Location latestLocation;
+    private Location previousLocation;
     private List<CourseRoutePointsGateway.RoutePoint> currentRoutePoints = Collections.emptyList();
     private MapLibreMap rideMapLibreMap;
     private String currentMapMessage;
@@ -102,6 +107,7 @@ public class RideEntryActivity extends AppCompatActivity {
     private final RidePolicyEvaluationGateway ridePolicyEvaluationGateway = new HttpRidePolicyEvaluationGateway();
     private final RidePolicyUiMapper ridePolicyUiMapper = new RidePolicyUiMapper();
     private final CourseRoutePointsGateway courseRoutePointsGateway = new HttpCourseRoutePointsGateway();
+    private final RideSpeedFormatter rideSpeedFormatter = new RideSpeedFormatter();
 
     private final ActivityResultLauncher<String> locationPermissionLauncher = registerForActivityResult(
             new ActivityResultContracts.RequestPermission(),
@@ -133,6 +139,8 @@ public class RideEntryActivity extends AppCompatActivity {
         rideFlowStatusTextView = findViewById(R.id.rideFlowStatusTextView);
         rideMapStatusTextView = findViewById(R.id.rideMapStatusTextView);
         ridePolicyBannerTextView = findViewById(R.id.ridePolicyBannerTextView);
+        rideSpeedValueTextView = findViewById(R.id.rideSpeedValueTextView);
+        rideSpeedMessageTextView = findViewById(R.id.rideSpeedMessageTextView);
         ridePolicyStateTextView = findViewById(R.id.ridePolicyStateTextView);
         ridePolicyMessageTextView = findViewById(R.id.ridePolicyMessageTextView);
         rideMyLocationButton = findViewById(R.id.rideMyLocationButton);
@@ -322,6 +330,7 @@ public class RideEntryActivity extends AppCompatActivity {
         }
 
         latestLocation = resolveBestLastKnownLocation();
+        renderSpeedCard();
         renderCurrentLocationOnMap();
         renderMapOverlays();
 
@@ -371,21 +380,35 @@ public class RideEntryActivity extends AppCompatActivity {
             }
 
             List<String> providers = locationManager.getProviders(true);
-            Location latestLocation = null;
+            Location newestLocation = null;
             for (String provider : providers) {
                 Location candidate = locationManager.getLastKnownLocation(provider);
                 if (candidate == null) {
                     continue;
                 }
-                if (latestLocation == null || candidate.getTime() > latestLocation.getTime()) {
-                    latestLocation = candidate;
+                if (newestLocation == null || candidate.getTime() > newestLocation.getTime()) {
+                    newestLocation = candidate;
                 }
             }
 
-            return latestLocation;
+            if (newestLocation != null && latestLocation != null && newestLocation != latestLocation) {
+                previousLocation = latestLocation;
+            }
+
+            return newestLocation;
         } catch (SecurityException exception) {
             renderPolicyError(getString(R.string.ride_policy_location_error_message));
             return null;
+        }
+    }
+
+    private void renderSpeedCard() {
+        RideSpeedUiState uiState = rideSpeedFormatter.format(latestLocation, previousLocation);
+        rideSpeedValueTextView.setText(uiState.getSpeedText());
+        if (uiState.getMessage() == null || uiState.getMessage().isBlank()) {
+            rideSpeedMessageTextView.setText(R.string.ride_speed_message_default);
+        } else {
+            rideSpeedMessageTextView.setText(uiState.getMessage());
         }
     }
 

--- a/app/src/main/java/com/bikeprojectminji/bikefront/speed/RideSpeedFormatter.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/speed/RideSpeedFormatter.java
@@ -1,0 +1,53 @@
+package com.bikeprojectminji.bikefront.speed;
+
+import android.location.Location;
+
+public class RideSpeedFormatter {
+
+    private static final float MIN_DISTANCE_METERS = 1f;
+    private static final long MIN_ELAPSED_MILLIS = 1_000L;
+
+    public RideSpeedUiState format(Location currentLocation, Location previousLocation) {
+        if (currentLocation == null) {
+            return new RideSpeedUiState("--", "현재 위치를 확인하는 중입니다.");
+        }
+
+        int speedKmh = resolveSpeedKmh(currentLocation, previousLocation);
+        String message = null;
+
+        if (currentLocation.hasAccuracy() && currentLocation.getAccuracy() > 50f) {
+            message = "현재 위치 정보가 불안정합니다.";
+        }
+
+        return new RideSpeedUiState(speedKmh + "km/h", message);
+    }
+
+    private int resolveSpeedKmh(Location currentLocation, Location previousLocation) {
+        if (currentLocation.hasSpeed()) {
+            return normalizeSpeedKmh(currentLocation.getSpeed() * 3.6f);
+        }
+
+        if (previousLocation == null) {
+            return 0;
+        }
+
+        long elapsedMillis = Math.abs(currentLocation.getTime() - previousLocation.getTime());
+        float distanceMeters = currentLocation.distanceTo(previousLocation);
+
+        if (elapsedMillis < MIN_ELAPSED_MILLIS || distanceMeters < MIN_DISTANCE_METERS) {
+            return 0;
+        }
+
+        float elapsedSeconds = elapsedMillis / 1000f;
+        float fallbackSpeedKmh = (distanceMeters / elapsedSeconds) * 3.6f;
+        return normalizeSpeedKmh(fallbackSpeedKmh);
+    }
+
+    private int normalizeSpeedKmh(float speedKmh) {
+        if (speedKmh < 1f) {
+            return 0;
+        }
+
+        return Math.round(speedKmh);
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/speed/RideSpeedUiState.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/speed/RideSpeedUiState.java
@@ -1,0 +1,20 @@
+package com.bikeprojectminji.bikefront.speed;
+
+public class RideSpeedUiState {
+
+    private final String speedText;
+    private final String message;
+
+    public RideSpeedUiState(String speedText, String message) {
+        this.speedText = speedText;
+        this.message = message;
+    }
+
+    public String getSpeedText() {
+        return speedText;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/app/src/main/res/layout/activity_ride_entry.xml
+++ b/app/src/main/res/layout/activity_ride_entry.xml
@@ -176,7 +176,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/ridePolicyContainer"
+        android:id="@+id/rideSpeedContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/section_spacing"
@@ -186,6 +186,47 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/ridePermissionContainer">
+
+        <TextView
+            android:id="@+id/rideSpeedTitleTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/ride_speed_card_title"
+            android:textColor="@color/text_primary"
+            android:textSize="@dimen/text_body_large"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/rideSpeedValueTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/s_spacing"
+            android:text="@string/ride_speed_loading"
+            android:textColor="@color/text_primary"
+            android:textSize="28sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/rideSpeedMessageTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/xs_spacing"
+            android:text="@string/ride_speed_message_default"
+            android:textColor="@color/text_secondary"
+            android:textSize="@dimen/text_body" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/ridePolicyContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/section_spacing"
+        android:background="@drawable/bg_card_surface"
+        android:orientation="vertical"
+        android:padding="@dimen/card_padding"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/rideSpeedContainer">
 
         <TextView
             android:id="@+id/ridePolicyTitleTextView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,9 @@
     <string name="ride_map_route_loading_message">경로를 불러오는 중입니다.</string>
     <string name="ride_map_route_error_message">경로를 불러오지 못했습니다.</string>
     <string name="ride_map_route_empty_message">경로 정보가 없습니다.</string>
+    <string name="ride_speed_card_title">속도</string>
+    <string name="ride_speed_loading">--</string>
+    <string name="ride_speed_message_default">현재 속도를 표시합니다.</string>
     <string name="ride_policy_card_title">주행 정책</string>
     <string name="ride_policy_pending_label">판단 보류</string>
     <string name="ride_policy_error_label">정책 확인 실패</string>


### PR DESCRIPTION
## 작업 목적
- ride 화면에서 현재 속도를 표시하는 속도 카드를 추가합니다.

## 변경 내용
- speed/ 패키지에 속도 포맷터와 UI state를 추가했습니다.
- RideEntryActivity에서 현재 위치를 기반으로 속도 카드를 렌더링합니다.
- Location.getSpeed()를 우선 사용하고, 없으면 이전 위치와의 거리/시간으로 최소 fallback 계산을 수행합니다.
- 1km/h 미만은 