### PR TITLE
ride HUD 레이아웃과 지도 스타일 개선

### DIFF
--- a/app/src/main/assets/osm_raster_style.json
+++ b/app/src/main/assets/osm_raster_style.json
@@ -1,0 +1,23 @@
+{
+  "version": 8,
+  "name": "OSM Raster",
+  "sources": {
+    "osm-raster": {
+      "type": "raster",
+      "tiles": [
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+      ],
+      "tileSize": 256,
+      "attribution": "© OpenStreetMap contributors"
+    }
+  },
+  "layers": [
+    {
+      "id": "osm-raster-layer",
+      "type": "raster",
+      "source": "osm-raster",
+      "minzoom": 0,
+      "maxzoom": 19
+    }
+  ]
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/config/AppConfig.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/config/AppConfig.java
@@ -3,7 +3,7 @@ package com.bikeprojectminji.bikefront.config;
 public final class AppConfig {
 
     public static final String API_BASE_URL = "http://10.0.2.2:8080";
-    public static final String MAP_STYLE_URL = "https://demotiles.maplibre.org/style.json";
+    public static final String MAP_STYLE_URL = "asset://osm_raster_style.json";
     public static final int CONNECT_TIMEOUT_MS = 5000;
     public static final int READ_TIMEOUT_MS = 5000;
 

--- a/app/src/main/res/drawable/bg_hud_surface.xml
+++ b/app/src/main/res/drawable/bg_hud_surface.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/hud_surface" />
+    <corners android:radius="@dimen/card_radius" />
+    <stroke
+        android:width="@dimen/stroke_width"
+        android:color="#26FFFFFF" />
+</shape>

--- a/app/src/main/res/layout/activity_ride_entry.xml
+++ b/app/src/main/res/layout/activity_ride_entry.xml
@@ -21,7 +21,7 @@
     <FrameLayout
         android:id="@+id/rideMapContainer"
         android:layout_width="0dp"
-        android:layout_height="@dimen/ride_map_height"
+        android:layout_height="@dimen/ride_map_hud_height"
         android:layout_marginTop="@dimen/section_spacing"
         android:background="@drawable/bg_card_surface"
         app:layout_constraintEnd_toEndOf="parent"
@@ -65,6 +65,181 @@
             android:textColor="@color/error_text"
             android:textSize="@dimen/text_body"
             android:visibility="gone" />
+
+        <LinearLayout
+            android:id="@+id/rideHudOverlayContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_margin="@dimen/card_padding"
+            android:layout_marginBottom="@dimen/ride_hud_bottom_margin"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/rideHudTopRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:id="@+id/rideSpeedContainer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_hud_surface"
+                    android:elevation="4dp"
+                    android:orientation="vertical"
+                    android:padding="@dimen/hud_card_padding">
+
+                    <TextView
+                        android:id="@+id/rideSpeedTitleTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/ride_speed_card_title"
+                        android:textColor="@color/hud_text_primary"
+                        android:textSize="@dimen/text_body_small"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/rideSpeedValueTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/xs_spacing"
+                        android:text="@string/ride_speed_loading"
+                        android:textColor="@color/hud_text_primary"
+                        android:textSize="24sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/rideSpeedMessageTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/xs_spacing"
+                        android:text="@string/ride_speed_message_default"
+                        android:textColor="@color/hud_text_secondary"
+                        android:textSize="@dimen/text_body_small" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/rideWeatherContainer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/s_spacing"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_hud_surface"
+                    android:elevation="4dp"
+                    android:orientation="vertical"
+                    android:padding="@dimen/hud_card_padding">
+
+                    <TextView
+                        android:id="@+id/rideWeatherTitleTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/ride_weather_card_title"
+                        android:textColor="@color/hud_text_primary"
+                        android:textSize="@dimen/text_body_small"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/rideWeatherValueTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/xs_spacing"
+                        android:text="@string/ride_weather_loading_value"
+                        android:textColor="@color/hud_text_primary"
+                        android:textSize="20sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/rideWeatherStatusTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/xs_spacing"
+                        android:text="@string/ride_weather_loading_message"
+                        android:textColor="@color/hud_text_secondary"
+                        android:textSize="@dimen/text_body_small" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/rideWindContainer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/s_spacing"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_hud_surface"
+                    android:elevation="4dp"
+                    android:orientation="vertical"
+                    android:padding="@dimen/hud_card_padding">
+
+                    <TextView
+                        android:id="@+id/rideWindTitleTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/ride_wind_card_title"
+                        android:textColor="@color/hud_text_primary"
+                        android:textSize="@dimen/text_body_small"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/rideWindValueTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/xs_spacing"
+                        android:text="@string/ride_wind_loading_value"
+                        android:textColor="@color/hud_text_primary"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/rideWindStatusTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/xs_spacing"
+                        android:text="@string/ride_wind_loading_message"
+                        android:textColor="@color/hud_text_secondary"
+                        android:textSize="@dimen/text_body_small" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/ridePolicyContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/s_spacing"
+                android:background="@drawable/bg_hud_surface"
+                android:elevation="4dp"
+                android:orientation="vertical"
+                android:padding="@dimen/hud_card_padding">
+
+                <TextView
+                    android:id="@+id/ridePolicyTitleTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/ride_policy_card_title"
+                    android:textColor="@color/hud_text_primary"
+                    android:textSize="@dimen/text_body_small"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/ridePolicyStateTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/xs_spacing"
+                    android:text="@string/ride_policy_pending_label"
+                    android:textColor="@color/success_text"
+                    android:textSize="@dimen/text_body_large"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/ridePolicyMessageTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/xs_spacing"
+                    android:text="@string/ride_policy_loading_message"
+                    android:textColor="@color/hud_text_secondary"
+                    android:textSize="@dimen/text_body_small" />
+            </LinearLayout>
+        </LinearLayout>
     </FrameLayout>
 
     <LinearLayout
@@ -175,176 +350,6 @@
         </LinearLayout>
     </LinearLayout>
 
-    <LinearLayout
-        android:id="@+id/rideSpeedContainer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/section_spacing"
-        android:background="@drawable/bg_card_surface"
-        android:orientation="vertical"
-        android:padding="@dimen/card_padding"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ridePermissionContainer">
-
-        <TextView
-            android:id="@+id/rideSpeedTitleTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/ride_speed_card_title"
-            android:textColor="@color/text_primary"
-            android:textSize="@dimen/text_body_large"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/rideSpeedValueTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/s_spacing"
-            android:text="@string/ride_speed_loading"
-            android:textColor="@color/text_primary"
-            android:textSize="28sp"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/rideSpeedMessageTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/xs_spacing"
-            android:text="@string/ride_speed_message_default"
-            android:textColor="@color/text_secondary"
-            android:textSize="@dimen/text_body" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/ridePolicyContainer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/section_spacing"
-        android:background="@drawable/bg_card_surface"
-        android:orientation="vertical"
-        android:padding="@dimen/card_padding"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/rideSpeedContainer">
-
-        <TextView
-            android:id="@+id/ridePolicyTitleTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/ride_policy_card_title"
-            android:textColor="@color/text_primary"
-            android:textSize="@dimen/text_body_large"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/ridePolicyStateTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/s_spacing"
-            android:text="@string/ride_policy_pending_label"
-            android:textColor="@color/info_text"
-            android:textSize="@dimen/text_body_large"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/ridePolicyMessageTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/xs_spacing"
-            android:text="@string/ride_policy_loading_message"
-            android:textColor="@color/text_secondary"
-            android:textSize="@dimen/text_body" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/rideWeatherRowContainer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/section_spacing"
-        android:orientation="horizontal"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ridePolicyContainer">
-
-        <LinearLayout
-            android:id="@+id/rideWeatherContainer"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:background="@drawable/bg_card_surface"
-            android:orientation="vertical"
-            android:padding="@dimen/card_padding">
-
-            <TextView
-                android:id="@+id/rideWeatherTitleTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/ride_weather_card_title"
-                android:textColor="@color/text_primary"
-                android:textSize="@dimen/text_body_large"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/rideWeatherValueTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/s_spacing"
-                android:text="@string/ride_weather_loading_value"
-                android:textColor="@color/text_primary"
-                android:textSize="24sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/rideWeatherStatusTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/xs_spacing"
-                android:text="@string/ride_weather_loading_message"
-                android:textColor="@color/text_secondary"
-                android:textSize="@dimen/text_body" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/rideWindContainer"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/s_spacing"
-            android:layout_weight="1"
-            android:background="@drawable/bg_card_surface"
-            android:orientation="vertical"
-            android:padding="@dimen/card_padding">
-
-            <TextView
-                android:id="@+id/rideWindTitleTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/ride_wind_card_title"
-                android:textColor="@color/text_primary"
-                android:textSize="@dimen/text_body_large"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/rideWindValueTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/s_spacing"
-                android:text="@string/ride_wind_loading_value"
-                android:textColor="@color/text_primary"
-                android:textSize="20sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/rideWindStatusTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/xs_spacing"
-                android:text="@string/ride_wind_loading_message"
-                android:textColor="@color/text_secondary"
-                android:textSize="@dimen/text_body" />
-        </LinearLayout>
-    </LinearLayout>
-
     <TextView
         android:id="@+id/rideFlowStatusTextView"
         android:layout_width="0dp"
@@ -355,6 +360,6 @@
         android:textSize="@dimen/text_body"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/rideWeatherRowContainer" />
+        app:layout_constraintTop_toBottomOf="@id/ridePermissionContainer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,4 +11,7 @@
     <color name="info_text">#FF175CD3</color>
     <color name="banner_warning_background">#FFFEE4E2</color>
     <color name="route_line">#FF175CD3</color>
+    <color name="hud_surface">#E6111827</color>
+    <color name="hud_text_primary">#FFFFFFFF</color>
+    <color name="hud_text_secondary">#FFD0D5DD</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,5 +16,8 @@
     <dimen name="stroke_width">1dp</dimen>
     <dimen name="min_touch_target">48dp</dimen>
     <dimen name="ride_map_height">280dp</dimen>
+    <dimen name="ride_map_hud_height">420dp</dimen>
     <dimen name="ride_map_camera_padding">48dp</dimen>
+    <dimen name="hud_card_padding">12dp</dimen>
+    <dimen name="ride_hud_bottom_margin">56dp</dimen>
 </resources>


### PR DESCRIPTION
## 작업 목적
- ride 화면에서 날씨/속도/정책이 첫 화면에 바로 보이도록 HUD 레이아웃으로 재배치하고, 지도 스타일을 더 보기 좋은 OSM 계열로 교체합니다.

## 변경 내용
- 속도/날씨/바람/정책 카드를 지도 위 HUD 오버레이로 이동했습니다.
- 지도 높이를 늘리고 반투명 HUD surface를 추가했습니다.
- 기존 MapLibre demo style 대신 앱 내부 osm_raster_style.json을 사용하도록 변경했습니다.
- OSM raster 타일을 사용하는 token-free 스타일로 전환했습니다.
- 하단 영역은 코스 요약 / 권한 상태 / 보조 메시지 중심으로 단순화했습니다.

## 확인 방법
- gradlew.bat :app:compileDebugJavaWithJavac
- gradlew.bat :app:assembleDebug
- ride 화면 첫 진입 시 날씨/속도/정책이 지도 위 HUD로 보이는지 확인

## self-review 결과
- 판정: OK with comments
- 머지 가능 여부: 보완 후 가능
- 확인한 핵심: compile/assemble은 통과했고, 사용자 요구(날씨가 안 보임, 지도가 별로임)에 직접 대응하는 구조 변경입니다. 다만 실제 기기에서 HUD 겹침과 OSM 타일 네트워크 의존은 한 번 더 보는 게 좋습니다.
- 이슈: closes #16