### PR TITLE
ride 시작 흐름과 HUD를 보정

### DIFF
--- a/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
@@ -89,6 +89,8 @@ public class RideEntryActivity extends AppCompatActivity {
     private TextView rideFlowStatusTextView;
     private TextView rideMapStatusTextView;
     private TextView ridePolicyBannerTextView;
+    private View rideSummaryContainer;
+    private View ridePermissionContainer;
     private TextView rideSpeedValueTextView;
     private TextView rideSpeedMessageTextView;
     private TextView rideWeatherValueTextView;
@@ -98,6 +100,7 @@ public class RideEntryActivity extends AppCompatActivity {
     private TextView ridePolicyStateTextView;
     private TextView ridePolicyMessageTextView;
     private Button rideMyLocationButton;
+    private Button rideStartButton;
     private Button ridePermissionRetryButton;
     private Button ridePermissionSettingsButton;
     private MapView rideMapView;
@@ -113,6 +116,7 @@ public class RideEntryActivity extends AppCompatActivity {
     private boolean locationUpdatesRegistered;
     private boolean policyRequestInFlight;
     private boolean weatherRequestInFlight;
+    private boolean startRequested;
     private Location latestLocation;
     private Location previousLocation;
     private Location lastPolicyEvaluationLocation;
@@ -159,6 +163,9 @@ public class RideEntryActivity extends AppCompatActivity {
 
         rideMapView = findViewById(R.id.rideMapView);
         rideMapView.onCreate(savedInstanceState);
+        TextView screenTitleTextView = findViewById(R.id.rideTitleTextView);
+        rideSummaryContainer = findViewById(R.id.rideSummaryContainer);
+        ridePermissionContainer = findViewById(R.id.ridePermissionContainer);
         TextView titleTextView = findViewById(R.id.rideCourseTitleTextView);
         TextView distanceTextView = findViewById(R.id.rideCourseDistanceTextView);
         TextView durationTextView = findViewById(R.id.rideCourseDurationTextView);
@@ -176,11 +183,13 @@ public class RideEntryActivity extends AppCompatActivity {
         ridePolicyStateTextView = findViewById(R.id.ridePolicyStateTextView);
         ridePolicyMessageTextView = findViewById(R.id.ridePolicyMessageTextView);
         rideMyLocationButton = findViewById(R.id.rideMyLocationButton);
+        rideStartButton = findViewById(R.id.rideStartButton);
         ridePermissionRetryButton = findViewById(R.id.ridePermissionRetryButton);
         ridePermissionSettingsButton = findViewById(R.id.ridePermissionSettingsButton);
 
         Intent intent = getIntent();
         courseId = intent.getLongExtra(EXTRA_COURSE_ID, -1L);
+        screenTitleTextView.setText(intent.getStringExtra(EXTRA_TITLE));
         titleTextView.setText(intent.getStringExtra(EXTRA_TITLE));
         distanceTextView.setText(intent.getStringExtra(EXTRA_DISTANCE_TEXT));
         durationTextView.setText(intent.getStringExtra(EXTRA_DURATION_TEXT));
@@ -198,6 +207,7 @@ public class RideEntryActivity extends AppCompatActivity {
             });
         });
 
+        rideStartButton.setOnClickListener(v -> requestRideStart());
         rideMyLocationButton.setOnClickListener(v -> centerCameraOnCurrentLocation());
         ridePermissionRetryButton.setOnClickListener(v -> requestLocationPermission());
         ridePermissionSettingsButton.setOnClickListener(v -> openAppSettings());
@@ -219,6 +229,8 @@ public class RideEntryActivity extends AppCompatActivity {
             renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
             requestLocationPermission();
         }
+
+        renderRideStartButton();
     }
 
     @Override
@@ -327,6 +339,7 @@ public class RideEntryActivity extends AppCompatActivity {
 
         switch (newState) {
             case REQUESTING:
+                ridePermissionContainer.setVisibility(View.VISIBLE);
                 ridePermissionMessageTextView.setText(R.string.ride_permission_resuming_message);
                 ridePermissionBlockedFeaturesTextView.setText(R.string.ride_location_status_blocked);
                 ridePermissionRetryButton.setEnabled(false);
@@ -336,6 +349,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
                 break;
             case NEED_PERMISSION:
+                ridePermissionContainer.setVisibility(View.VISIBLE);
                 ridePermissionMessageTextView.setText(R.string.ride_permission_message);
                 ridePermissionBlockedFeaturesTextView.setText(R.string.ride_location_status_blocked);
                 ridePermissionRetryButton.setEnabled(true);
@@ -345,6 +359,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_permission_blocked_message));
                 break;
             case DENIED:
+                ridePermissionContainer.setVisibility(View.VISIBLE);
                 ridePermissionMessageTextView.setText(R.string.ride_permission_message);
                 ridePermissionBlockedFeaturesTextView.setText(R.string.ride_location_status_blocked);
                 ridePermissionRetryButton.setEnabled(true);
@@ -354,6 +369,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_permission_blocked_message));
                 break;
             case SETTINGS_REQUIRED:
+                ridePermissionContainer.setVisibility(View.VISIBLE);
                 ridePermissionMessageTextView.setText(R.string.ride_permission_settings_message);
                 ridePermissionBlockedFeaturesTextView.setText(R.string.ride_location_status_blocked);
                 ridePermissionRetryButton.setEnabled(true);
@@ -363,6 +379,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_permission_blocked_message));
                 break;
             case GRANTED:
+                ridePermissionContainer.setVisibility(View.GONE);
                 ridePermissionMessageTextView.setText(R.string.ride_permission_resuming_message);
                 ridePermissionBlockedFeaturesTextView.setText(R.string.ride_location_status_resumed);
                 ridePermissionRetryButton.setVisibility(View.GONE);
@@ -371,6 +388,7 @@ public class RideEntryActivity extends AppCompatActivity {
                 break;
         }
 
+        renderRideStartButton();
         syncGuidanceMessages();
     }
 
@@ -425,12 +443,23 @@ public class RideEntryActivity extends AppCompatActivity {
                 }
 
                 if (PHASE_PRE_START.equals(phase) && "ELIGIBLE".equals(result.getStartGate().getStatus())) {
-                    ridePhase = PHASE_ACTIVE;
-                    evaluateRidePolicy(location, PHASE_ACTIVE, true);
+                    if (startRequested) {
+                        startRequested = false;
+                        ridePhase = PHASE_ACTIVE;
+                        renderRideStartButton();
+                        evaluateRidePolicy(location, PHASE_ACTIVE, true);
+                        return;
+                    }
+
+                    ridePhase = PHASE_PRE_START;
+                    renderRideStartButton();
+                    renderPolicyResult(ridePolicyUiMapper.map(result));
                     return;
                 }
 
                 ridePhase = result.getPhase();
+                startRequested = false;
+                renderRideStartButton();
                 renderPolicyResult(ridePolicyUiMapper.map(result));
             }
 
@@ -441,9 +470,32 @@ public class RideEntryActivity extends AppCompatActivity {
                     return;
                 }
 
+                startRequested = false;
+                renderRideStartButton();
                 renderPolicyError(message);
             }
         });
+    }
+
+    private void requestRideStart() {
+        if (latestLocation == null) {
+            renderPolicyPending(getString(R.string.ride_policy_pending_label), getString(R.string.ride_policy_loading_message));
+            return;
+        }
+
+        startRequested = true;
+        renderRideStartButton();
+        evaluateRidePolicy(latestLocation, PHASE_PRE_START, true);
+    }
+
+    private void renderRideStartButton() {
+        if (!hasLocationPermission() || PHASE_ACTIVE.equals(ridePhase)) {
+            rideStartButton.setVisibility(View.GONE);
+            return;
+        }
+
+        rideStartButton.setVisibility(View.VISIBLE);
+        rideStartButton.setEnabled(!startRequested);
     }
 
     private boolean shouldReevaluateActivePolicy(Location location) {

--- a/app/src/main/res/layout/activity_ride_entry.xml
+++ b/app/src/main/res/layout/activity_ride_entry.xml
@@ -76,9 +76,64 @@
             android:orientation="vertical">
 
             <LinearLayout
+                android:id="@+id/rideSummaryContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_hud_surface"
+                android:elevation="4dp"
+                android:orientation="vertical"
+                android:padding="@dimen/hud_card_padding">
+
+                <TextView
+                    android:id="@+id/rideCourseTitleTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hud_text_primary"
+                    android:textSize="@dimen/text_body_large"
+                    android:textStyle="bold" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/xs_spacing"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/rideCourseDistanceTextView"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/hud_text_secondary"
+                        android:textSize="@dimen/text_body_small" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="@dimen/s_spacing"
+                        android:text="·"
+                        android:textColor="@color/hud_text_secondary"
+                        android:textSize="@dimen/text_body_small" />
+
+                    <TextView
+                        android:id="@+id/rideCourseDurationTextView"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/hud_text_secondary"
+                        android:textSize="@dimen/text_body_small" />
+                </LinearLayout>
+
+                <Button
+                    android:id="@+id/rideStartButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/s_spacing"
+                    android:text="@string/start_button" />
+            </LinearLayout>
+
+            <LinearLayout
                 android:id="@+id/rideHudTopRow"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/s_spacing"
                 android:orientation="horizontal">
 
                 <LinearLayout
@@ -243,52 +298,6 @@
     </FrameLayout>
 
     <LinearLayout
-        android:id="@+id/rideSummaryContainer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/section_spacing"
-        android:background="@drawable/bg_card_surface"
-        android:orientation="vertical"
-        android:padding="@dimen/card_padding"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/rideMapContainer">
-
-        <TextView
-            android:id="@+id/rideCourseTitleTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
-            android:textSize="@dimen/text_section_title"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/rideCourseDistanceTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/s_spacing"
-            android:textColor="@color/text_secondary"
-            android:textSize="@dimen/text_body" />
-
-        <TextView
-            android:id="@+id/rideCourseDurationTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/xs_spacing"
-            android:textColor="@color/text_secondary"
-            android:textSize="@dimen/text_body" />
-
-        <TextView
-            android:id="@+id/ridePlaceholderTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/section_spacing"
-            android:text="@string/ride_placeholder_message"
-            android:textColor="@color/text_secondary"
-            android:textSize="@dimen/text_body" />
-    </LinearLayout>
-
-    <LinearLayout
         android:id="@+id/ridePermissionContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -298,7 +307,7 @@
         android:padding="@dimen/card_padding"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/rideSummaryContainer">
+        app:layout_constraintTop_toBottomOf="@id/rideMapContainer">
 
         <TextView
             android:id="@+id/ridePermissionTitleTextView"


### PR DESCRIPTION
## 작업 목적
- ride 화면에서 명시적 시작 전에는 ACTIVE로 승격되지 않도록 고치고, 코스 요약을 더 HUD처럼 보이게 보정합니다.

## 변경 내용
- PRE_START 평가에서 ELIGIBLE가 나와도 사용자가 시작 버튼을 누르기 전에는 ACTIVE로 승격되지 않도록 수정했습니다.
- ideStartButton을 추가하고, 사용자가 명시적으로 시작을 요청했을 때만 ACTIVE 평가로 넘어가게 했습니다.
- 코스 요약(제목/거리/예상 시간)을 지도 위 HUD 영역으로 이동했습니다.
- 위치 권한 허용 후 권한 카드가 계속 화면 아래 남지 않도록 숨김 처리했습니다.

## 확인 방법
- gradlew.bat :app:compileDebugJavaWithJavac
- gradlew.bat :app:assembleDebug
- 시작 버튼을 누르기 전에는 주행 중이 아니라 주행 가능/판단 보류로만 보이는지 확인

## self-review 결과
- 판정: OK with comments
- 머지 가능 여부: 보완 후 가능
- 확인한 핵심: compile/assemble은 통과했고, 자동 ACTIVE 승격 버그는 제거했습니다. 다만 실제 기기/에뮬레이터에서 시작 버튼 이후 ACTIVE 전환 UX는 한 번 더 눈으로 보는 것이 좋습니다.
- 이슈: closes #18