### PR TITLE
fix: 즉시 종료 시 route point 저장 누락 보강

### DIFF
--- a/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/RideEntryActivity.java
@@ -558,6 +558,7 @@ public class RideEntryActivity extends AppCompatActivity {
     }
 
     private void completeRide() {
+        ensureRecordedFallbackPoint();
         ridePhase = PHASE_COMPLETE;
         renderRideStartButton();
         renderPostRideState();
@@ -643,6 +644,17 @@ public class RideEntryActivity extends AppCompatActivity {
             return 0;
         }
         return (int) java.time.Duration.between(activeRideStartedAt, OffsetDateTime.now()).getSeconds();
+    }
+
+    private void ensureRecordedFallbackPoint() {
+        if (latestLocation == null || !recordedRidePoints.isEmpty()) {
+            return;
+        }
+        recordedRidePoints.add(new RideRecordGateway.RideRecordPoint(
+                1,
+                latestLocation.getLatitude(),
+                latestLocation.getLongitude()
+        ));
     }
 
     private void saveRecordedRidePoints(@NonNull Bundle outState) {


### PR DESCRIPTION
## Summary
- 주행 시작 직후 바로 종료해도 최소 route point 1개를 보장하도록 보강했습니다.
- 빈 routePoints 때문에 ride record 저장이 실패하는 흐름을 막는 핫픽스입니다.

## Verification
- `./gradlew.bat build`