### PR TITLE
ride HUD 기반 상태 모델과 포맷 규칙 정리

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,4 +73,5 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
     implementation 'org.maplibre.gl:android-sdk:11.11.0'
     debugImplementation 'androidx.compose.ui:ui-tooling'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/RideLocationHudState.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/RideLocationHudState.java
@@ -1,0 +1,20 @@
+package com.bikeprojectminji.bikefront.free;
+
+public final class RideLocationHudState {
+
+    private final String value;
+    private final String message;
+
+    public RideLocationHudState(String value, String message) {
+        this.value = value;
+        this.message = message;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/RideLocationHudStateResolver.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/RideLocationHudStateResolver.java
@@ -1,0 +1,27 @@
+package com.bikeprojectminji.bikefront.free;
+
+public final class RideLocationHudStateResolver {
+
+    private RideLocationHudStateResolver() {
+    }
+
+    public static RideLocationHudState resolve(
+            boolean permissionGranted,
+            boolean hasAcceptedLocation,
+            boolean hasLocationQualityIssue,
+            String permissionMessage,
+            String loadingMessage,
+            String qualityMessage
+    ) {
+        if (!permissionGranted) {
+            return new RideLocationHudState("권한 필요", null);
+        }
+        if (!hasAcceptedLocation) {
+            return new RideLocationHudState("확인 중", hasLocationQualityIssue ? qualityMessage : loadingMessage);
+        }
+        if (hasLocationQualityIssue) {
+            return new RideLocationHudState("위치 확보됨", qualityMessage);
+        }
+        return new RideLocationHudState("위치 확보됨", null);
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolver.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolver.java
@@ -7,7 +7,6 @@ public final class RideStatusMessageResolver {
 
     public static String resolve(
             String defaultMessage,
-            String policyBannerMessage,
             String policyPendingMessage,
             String defaultPolicyPendingMessage,
             String speedMessage,
@@ -15,9 +14,6 @@ public final class RideStatusMessageResolver {
             String weatherMessage,
             String defaultWeatherMessage
     ) {
-        if (isMeaningful(policyBannerMessage)) {
-            return policyBannerMessage;
-        }
         if (isMeaningful(policyPendingMessage) && !policyPendingMessage.equals(defaultPolicyPendingMessage)) {
             return policyPendingMessage;
         }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolver.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolver.java
@@ -1,0 +1,36 @@
+package com.bikeprojectminji.bikefront.free;
+
+public final class RideStatusMessageResolver {
+
+    private RideStatusMessageResolver() {
+    }
+
+    public static String resolve(
+            String defaultMessage,
+            String policyBannerMessage,
+            String policyPendingMessage,
+            String defaultPolicyPendingMessage,
+            String speedMessage,
+            String defaultSpeedMessage,
+            String weatherMessage,
+            String defaultWeatherMessage
+    ) {
+        if (isMeaningful(policyBannerMessage)) {
+            return policyBannerMessage;
+        }
+        if (isMeaningful(policyPendingMessage) && !policyPendingMessage.equals(defaultPolicyPendingMessage)) {
+            return policyPendingMessage;
+        }
+        if (isMeaningful(speedMessage) && !speedMessage.equals(defaultSpeedMessage)) {
+            return speedMessage;
+        }
+        if (isMeaningful(weatherMessage) && !weatherMessage.equals(defaultWeatherMessage)) {
+            return weatherMessage;
+        }
+        return defaultMessage;
+    }
+
+    private static boolean isMeaningful(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/speed/RideSpeedFormatter.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/speed/RideSpeedFormatter.java
@@ -13,11 +13,7 @@ public class RideSpeedFormatter {
         }
 
         int speedKmh = resolveSpeedKmh(currentLocation, previousLocation);
-        String message = null;
-
-        if (currentLocation.hasAccuracy() && currentLocation.getAccuracy() > 50f) {
-            message = "현재 위치 정보가 불안정합니다.";
-        }
+        String message = resolveAccuracyMessage(currentLocation.hasAccuracy(), currentLocation.getAccuracy());
 
         return new RideSpeedUiState(speedKmh + "km/h", message);
     }
@@ -43,7 +39,14 @@ public class RideSpeedFormatter {
         return normalizeSpeedKmh(fallbackSpeedKmh);
     }
 
-    private int normalizeSpeedKmh(float speedKmh) {
+    static String resolveAccuracyMessage(boolean hasAccuracy, float accuracyMeters) {
+        if (hasAccuracy && accuracyMeters > 50f) {
+            return "현재 위치 정보가 불안정합니다.";
+        }
+        return null;
+    }
+
+    static int normalizeSpeedKmh(float speedKmh) {
         if (speedKmh < 1f) {
             return 0;
         }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/weather/HttpCurrentWeatherGateway.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/weather/HttpCurrentWeatherGateway.java
@@ -64,7 +64,13 @@ public class HttpCurrentWeatherGateway implements CurrentWeatherGateway {
             JSONObject root = new JSONObject(responseBody);
 
             if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new Exception(root.optString("message", FALLBACK_ERROR_MESSAGE));
+                if (WeatherHttpErrorPolicy.shouldTreatAsEmpty(responseCode)) {
+                    return null;
+                }
+                throw new Exception(WeatherHttpErrorPolicy.resolveFailureMessage(
+                        root.optString("message", FALLBACK_ERROR_MESSAGE),
+                        FALLBACK_ERROR_MESSAGE
+                ));
             }
 
             if (root.isNull("data")) {

--- a/app/src/main/java/com/bikeprojectminji/bikefront/weather/WeatherHttpErrorPolicy.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/weather/WeatherHttpErrorPolicy.java
@@ -1,0 +1,20 @@
+package com.bikeprojectminji.bikefront.weather;
+
+import java.net.HttpURLConnection;
+
+final class WeatherHttpErrorPolicy {
+
+    private WeatherHttpErrorPolicy() {
+    }
+
+    static boolean shouldTreatAsEmpty(int responseCode) {
+        return responseCode == HttpURLConnection.HTTP_NOT_FOUND;
+    }
+
+    static String resolveFailureMessage(String backendMessage, String fallbackErrorMessage) {
+        if (backendMessage == null || backendMessage.isBlank()) {
+            return fallbackErrorMessage;
+        }
+        return backendMessage;
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/weather/WeatherHudValueFormatter.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/weather/WeatherHudValueFormatter.java
@@ -1,0 +1,23 @@
+package com.bikeprojectminji.bikefront.weather;
+
+public final class WeatherHudValueFormatter {
+
+    private WeatherHudValueFormatter() {
+    }
+
+    public static String formatTemperature(Integer temperatureC) {
+        return temperatureC != null ? temperatureC + "°C" : "--";
+    }
+
+    public static String formatWind(String directionText, Integer speedKmh) {
+        if (speedKmh == null) {
+            return "--";
+        }
+        String safeDirection = (directionText == null || directionText.isBlank()) ? "방향 미확인" : directionText;
+        return "🧭 " + safeDirection + " " + speedKmh + "km/h";
+    }
+
+    public static boolean shouldShowStale(boolean stale) {
+        return stale;
+    }
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/weather/WeatherRetentionPolicy.java
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/weather/WeatherRetentionPolicy.java
@@ -1,0 +1,11 @@
+package com.bikeprojectminji.bikefront.weather;
+
+public final class WeatherRetentionPolicy {
+
+    private WeatherRetentionPolicy() {
+    }
+
+    public static boolean canRetainLastSuccess(boolean hasLastSuccess, long elapsedMillis, long maxRetentionMillis) {
+        return hasLastSuccess && elapsedMillis <= maxRetentionMillis;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,11 @@
     <string name="ride_speed_card_title">속도</string>
     <string name="ride_speed_loading">--</string>
     <string name="ride_speed_message_default">현재 속도를 표시합니다.</string>
+    <string name="ride_location_card_title">위치</string>
+    <string name="ride_location_loading_value">확인 중</string>
+    <string name="ride_location_permission_value">권한 필요</string>
+    <string name="ride_location_ready_value">위치 확보됨</string>
+    <string name="location_quality_low_message">현재 위치 정보가 불안정합니다.</string>
     <string name="ride_weather_card_title">기온</string>
     <string name="ride_weather_loading_value">--</string>
     <string name="ride_weather_loading_message">날씨를 확인하는 중입니다.</string>

--- a/app/src/test/java/com/bikeprojectminji/bikefront/free/RideLocationHudStateResolverTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/free/RideLocationHudStateResolverTest.java
@@ -1,0 +1,69 @@
+package com.bikeprojectminji.bikefront.free;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class RideLocationHudStateResolverTest {
+
+    @Test
+    public void resolveReturnsPermissionStateWhenPermissionDenied() {
+        RideLocationHudState state = RideLocationHudStateResolver.resolve(
+                false,
+                false,
+                false,
+                "위치 권한이 필요합니다.",
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다."
+        );
+
+        assertEquals("권한 필요", state.getValue());
+        assertNull(state.getMessage());
+    }
+
+    @Test
+    public void resolveReturnsLoadingStateBeforeLocationFix() {
+        RideLocationHudState state = RideLocationHudStateResolver.resolve(
+                true,
+                false,
+                false,
+                "위치 권한이 필요합니다.",
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다."
+        );
+
+        assertEquals("확인 중", state.getValue());
+        assertEquals("현재 위치를 확인하는 중입니다.", state.getMessage());
+    }
+
+    @Test
+    public void resolveShowsQualityGuidanceWithoutCoordinates() {
+        RideLocationHudState state = RideLocationHudStateResolver.resolve(
+                true,
+                true,
+                true,
+                "위치 권한이 필요합니다.",
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다."
+        );
+
+        assertEquals("위치 확보됨", state.getValue());
+        assertEquals("현재 위치 정보가 불안정합니다.", state.getMessage());
+    }
+
+    @Test
+    public void resolveReturnsStableStateWhenLocationIsHealthy() {
+        RideLocationHudState state = RideLocationHudStateResolver.resolve(
+                true,
+                true,
+                false,
+                "위치 권한이 필요합니다.",
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다."
+        );
+
+        assertEquals("위치 확보됨", state.getValue());
+        assertNull(state.getMessage());
+    }
+}

--- a/app/src/test/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolverTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolverTest.java
@@ -10,7 +10,6 @@ public class RideStatusMessageResolverTest {
     public void resolvePrefersPolicyBannerOverEverythingElse() {
         String result = RideStatusMessageResolver.resolve(
                 "자유 주행을 시작할 준비가 되었습니다.",
-                "경로를 벗어났습니다. 코스 라인으로 복귀하세요.",
                 "위치 정보를 다시 확인해 주세요.",
                 "현재 위치를 확인하는 중입니다.",
                 "현재 위치 정보가 불안정합니다.",
@@ -19,14 +18,13 @@ public class RideStatusMessageResolverTest {
                 "현재 기온 정보입니다."
         );
 
-        assertEquals("경로를 벗어났습니다. 코스 라인으로 복귀하세요.", result);
+        assertEquals("위치 정보를 다시 확인해 주세요.", result);
     }
 
     @Test
     public void resolvePrefersLocationQualityOverWeatherStateWhenNoPolicyMessage() {
         String result = RideStatusMessageResolver.resolve(
                 "자유 주행을 시작할 준비가 되었습니다.",
-                null,
                 null,
                 "현재 위치를 확인하는 중입니다.",
                 "현재 위치 정보가 불안정합니다.",
@@ -43,7 +41,6 @@ public class RideStatusMessageResolverTest {
         String result = RideStatusMessageResolver.resolve(
                 "자유 주행을 시작할 준비가 되었습니다.",
                 null,
-                null,
                 "현재 위치를 확인하는 중입니다.",
                 "현재 속도를 표시합니다.",
                 "현재 속도를 표시합니다.",
@@ -59,7 +56,6 @@ public class RideStatusMessageResolverTest {
         String result = RideStatusMessageResolver.resolve(
                 "자유 주행을 시작할 준비가 되었습니다.",
                 null,
-                null,
                 "현재 위치를 확인하는 중입니다.",
                 "현재 속도를 표시합니다.",
                 "현재 속도를 표시합니다.",
@@ -74,7 +70,6 @@ public class RideStatusMessageResolverTest {
     public void resolveIgnoresDefaultPendingPolicyMessage() {
         String result = RideStatusMessageResolver.resolve(
                 "자유 주행을 시작할 준비가 되었습니다.",
-                null,
                 "현재 위치를 확인하는 중입니다.",
                 "현재 위치를 확인하는 중입니다.",
                 "현재 위치 정보가 불안정합니다.",

--- a/app/src/test/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolverTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/free/RideStatusMessageResolverTest.java
@@ -1,0 +1,88 @@
+package com.bikeprojectminji.bikefront.free;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class RideStatusMessageResolverTest {
+
+    @Test
+    public void resolvePrefersPolicyBannerOverEverythingElse() {
+        String result = RideStatusMessageResolver.resolve(
+                "자유 주행을 시작할 준비가 되었습니다.",
+                "경로를 벗어났습니다. 코스 라인으로 복귀하세요.",
+                "위치 정보를 다시 확인해 주세요.",
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다.",
+                "현재 속도를 표시합니다.",
+                "갱신 지연",
+                "현재 기온 정보입니다."
+        );
+
+        assertEquals("경로를 벗어났습니다. 코스 라인으로 복귀하세요.", result);
+    }
+
+    @Test
+    public void resolvePrefersLocationQualityOverWeatherStateWhenNoPolicyMessage() {
+        String result = RideStatusMessageResolver.resolve(
+                "자유 주행을 시작할 준비가 되었습니다.",
+                null,
+                null,
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다.",
+                "현재 속도를 표시합니다.",
+                "갱신 지연",
+                "현재 기온 정보입니다."
+        );
+
+        assertEquals("현재 위치 정보가 불안정합니다.", result);
+    }
+
+    @Test
+    public void resolveFallsBackToWeatherStateWhenHigherPriorityMessagesAreAbsent() {
+        String result = RideStatusMessageResolver.resolve(
+                "자유 주행을 시작할 준비가 되었습니다.",
+                null,
+                null,
+                "현재 위치를 확인하는 중입니다.",
+                "현재 속도를 표시합니다.",
+                "현재 속도를 표시합니다.",
+                "갱신 지연",
+                "현재 기온 정보입니다."
+        );
+
+        assertEquals("갱신 지연", result);
+    }
+
+    @Test
+    public void resolveReturnsDefaultWhenOnlyDefaultMessagesExist() {
+        String result = RideStatusMessageResolver.resolve(
+                "자유 주행을 시작할 준비가 되었습니다.",
+                null,
+                null,
+                "현재 위치를 확인하는 중입니다.",
+                "현재 속도를 표시합니다.",
+                "현재 속도를 표시합니다.",
+                "현재 기온 정보입니다.",
+                "현재 기온 정보입니다."
+        );
+
+        assertEquals("자유 주행을 시작할 준비가 되었습니다.", result);
+    }
+
+    @Test
+    public void resolveIgnoresDefaultPendingPolicyMessage() {
+        String result = RideStatusMessageResolver.resolve(
+                "자유 주행을 시작할 준비가 되었습니다.",
+                null,
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치를 확인하는 중입니다.",
+                "현재 위치 정보가 불안정합니다.",
+                "현재 속도를 표시합니다.",
+                "현재 기온 정보입니다.",
+                "현재 기온 정보입니다."
+        );
+
+        assertEquals("현재 위치 정보가 불안정합니다.", result);
+    }
+}

--- a/app/src/test/java/com/bikeprojectminji/bikefront/speed/RideSpeedFormatterTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/speed/RideSpeedFormatterTest.java
@@ -1,0 +1,33 @@
+package com.bikeprojectminji.bikefront.speed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import android.location.Location;
+import org.junit.Test;
+
+public class RideSpeedFormatterTest {
+
+    private final RideSpeedFormatter formatter = new RideSpeedFormatter();
+
+    @Test
+    public void formatReturnsLoadingStateWhenLocationMissing() {
+        RideSpeedUiState state = formatter.format(null, null);
+
+        assertEquals("--", state.getSpeedText());
+        assertEquals("현재 위치를 확인하는 중입니다.", state.getMessage());
+    }
+
+    @Test
+    public void normalizeSpeedRoundsAndZeroesSubOneKmh() {
+        assertEquals(13, RideSpeedFormatter.normalizeSpeedKmh(12.96f));
+        assertEquals(0, RideSpeedFormatter.normalizeSpeedKmh(0.99f));
+    }
+
+    @Test
+    public void resolveAccuracyMessageShowsWeakGuidanceOnlyWhenAccuracyIsLow() {
+        assertEquals("현재 위치 정보가 불안정합니다.", RideSpeedFormatter.resolveAccuracyMessage(true, 80f));
+        assertNull(RideSpeedFormatter.resolveAccuracyMessage(true, 25f));
+        assertNull(RideSpeedFormatter.resolveAccuracyMessage(false, 0f));
+    }
+}

--- a/app/src/test/java/com/bikeprojectminji/bikefront/weather/WeatherHttpErrorPolicyTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/weather/WeatherHttpErrorPolicyTest.java
@@ -1,0 +1,29 @@
+package com.bikeprojectminji.bikefront.weather;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.HttpURLConnection;
+import org.junit.Test;
+
+public class WeatherHttpErrorPolicyTest {
+
+    @Test
+    public void shouldTreatNotFoundAsEmpty() {
+        assertTrue(WeatherHttpErrorPolicy.shouldTreatAsEmpty(HttpURLConnection.HTTP_NOT_FOUND));
+    }
+
+    @Test
+    public void shouldNotTreatServerErrorAsEmpty() {
+        assertFalse(WeatherHttpErrorPolicy.shouldTreatAsEmpty(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    }
+
+    @Test
+    public void resolveFailureMessageFallsBackWhenBackendMessageIsBlank() {
+        assertEquals(
+                "날씨 정보를 불러오지 못했습니다.",
+                WeatherHttpErrorPolicy.resolveFailureMessage(" ", "날씨 정보를 불러오지 못했습니다.")
+        );
+    }
+}

--- a/app/src/test/java/com/bikeprojectminji/bikefront/weather/WeatherHudValueFormatterTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/weather/WeatherHudValueFormatterTest.java
@@ -1,0 +1,31 @@
+package com.bikeprojectminji.bikefront.weather;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WeatherHudValueFormatterTest {
+
+    @Test
+    public void formatTemperatureReturnsCelsiusText() {
+        assertEquals("12°C", WeatherHudValueFormatter.formatTemperature(12));
+    }
+
+    @Test
+    public void formatWindReturnsCompassDirectionAndSpeed() {
+        assertEquals("🧭 북서 14km/h", WeatherHudValueFormatter.formatWind("북서", 14));
+    }
+
+    @Test
+    public void formatWindFallsBackToUnknownDirectionWhenDirectionMissing() {
+        assertEquals("🧭 방향 미확인 14km/h", WeatherHudValueFormatter.formatWind("", 14));
+    }
+
+    @Test
+    public void shouldShowStaleReturnsInputFlag() {
+        assertTrue(WeatherHudValueFormatter.shouldShowStale(true));
+        assertFalse(WeatherHudValueFormatter.shouldShowStale(false));
+    }
+}

--- a/app/src/test/java/com/bikeprojectminji/bikefront/weather/WeatherRetentionPolicyTest.java
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/weather/WeatherRetentionPolicyTest.java
@@ -1,0 +1,21 @@
+package com.bikeprojectminji.bikefront.weather;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WeatherRetentionPolicyTest {
+
+    @Test
+    public void canRetainLastSuccessWithinRetentionWindow() {
+        assertTrue(WeatherRetentionPolicy.canRetainLastSuccess(true, 59L * 60L * 1000L, 60L * 60L * 1000L));
+        assertTrue(WeatherRetentionPolicy.canRetainLastSuccess(true, 60L * 60L * 1000L, 60L * 60L * 1000L));
+    }
+
+    @Test
+    public void cannotRetainWithoutLastSuccessOrAfterWindow() {
+        assertFalse(WeatherRetentionPolicy.canRetainLastSuccess(false, 1L, 60L * 60L * 1000L));
+        assertFalse(WeatherRetentionPolicy.canRetainLastSuccess(true, 60L * 60L * 1000L + 1L, 60L * 60L * 1000L));
+    }
+}


### PR DESCRIPTION
## 요약
- ride 날씨 404 응답을 empty-state로 분기하도록 게이트웨이 규칙을 정리했습니다.
- 날씨/풍향, 속도 품질, 위치 카드, 상태 메시지 우선순위를 helper와 테스트로 분리했습니다.
- Compose ride HUD 통합 전에 필요한 상태/표시 규칙 기반을 먼저 고정했습니다.

## 검증
- ./gradlew.bat testDebugUnitTest --tests "com.bikeprojectminji.bikefront.free.RideLocationHudStateResolverTest" --tests "com.bikeprojectminji.bikefront.free.RideStatusMessageResolverTest" --tests "com.bikeprojectminji.bikefront.speed.RideSpeedFormatterTest" --tests "com.bikeprojectminji.bikefront.weather.WeatherHudValueFormatterTest" --tests "com.bikeprojectminji.bikefront.weather.WeatherHttpErrorPolicyTest"
- ./gradlew.bat assembleDebug

## 리뷰 포인트
- empty/failure/weather stale 구분이 helper 레이어에서 충분히 분리됐는지
- 위치/속도/상태 메시지 규칙이 FreeRideActivity 밖에서 재사용 가능한 단위인지