### PR TITLE
Compose 주요 화면을 GAJA 스타일로 재디자인

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,11 +24,11 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField 'String', 'API_BASE_URL', '"http://10.0.2.2:8080"'
+            buildConfigField 'String', 'API_BASE_URL', '"https://bike-back-production.up.railway.app"'
             manifestPlaceholders = [usesCleartextTraffic: "true"]
         }
         release {
-            buildConfigField 'String', 'API_BASE_URL', '"https://api.example.invalid"'
+            buildConfigField 'String', 'API_BASE_URL', '"https://bike-back-production.up.railway.app"'
             manifestPlaceholders = [usesCleartextTraffic: "false"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/BikeFrontApp.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/BikeFrontApp.kt
@@ -2,20 +2,37 @@ package com.bikeprojectminji.bikefront.ui
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.DirectionsBike
 import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.filled.ListAlt
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.PersonOutline
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -36,10 +53,27 @@ import com.bikeprojectminji.bikefront.ui.screen.RideStartScreen
 private enum class MainTab(
     val route: String,
     val label: String,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector,
 ) {
-    RIDE_START("ride_start", "라이딩 시작"),
-    COURSES("courses", "코스"),
-    MY_INFO("my_info", "내 정보"),
+    RIDE_START(
+        route = "ride_start",
+        label = "라이딩",
+        selectedIcon = Icons.Filled.DirectionsBike,
+        unselectedIcon = Icons.AutoMirrored.Outlined.DirectionsBike,
+    ),
+    COURSES(
+        route = "courses",
+        label = "코스",
+        selectedIcon = Icons.Filled.ListAlt,
+        unselectedIcon = Icons.AutoMirrored.Outlined.ListAlt,
+    ),
+    MY_INFO(
+        route = "my_info",
+        label = "내 정보",
+        selectedIcon = Icons.Filled.Person,
+        unselectedIcon = Icons.Outlined.PersonOutline,
+    ),
 }
 
 private object Routes {
@@ -61,29 +95,58 @@ fun BikeFrontApp() {
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
+        containerColor = MaterialTheme.colorScheme.background,
         bottomBar = {
-            NavigationBar {
-                tabs.forEach { tab ->
-                    NavigationBarItem(
-                        selected = currentRoute == tab.route,
-                        onClick = {
-                            navController.navigate(tab.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+            // GAJA-styled bottom navigation with shadow
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = 16.dp,
+                        spotColor = Color(0x15000000),
+                    ),
+                color = MaterialTheme.colorScheme.surface,
+            ) {
+                NavigationBar(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    tonalElevation = 0.dp,
+                    modifier = Modifier.height(72.dp),
+                ) {
+                    tabs.forEach { tab ->
+                        val selected = currentRoute == tab.route
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = {
+                                navController.navigate(tab.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        icon = {
-                            when (tab) {
-                                MainTab.RIDE_START -> Icon(Icons.AutoMirrored.Outlined.DirectionsBike, contentDescription = tab.label)
-                                MainTab.COURSES -> Icon(Icons.AutoMirrored.Outlined.ListAlt, contentDescription = tab.label)
-                                MainTab.MY_INFO -> Icon(Icons.Outlined.PersonOutline, contentDescription = tab.label)
-                            }
-                        },
-                        label = { Text(tab.label) },
-                    )
+                            },
+                            icon = {
+                                Icon(
+                                    imageVector = if (selected) tab.selectedIcon else tab.unselectedIcon,
+                                    contentDescription = tab.label,
+                                    modifier = Modifier.size(26.dp),
+                                )
+                            },
+                            label = {
+                                Text(
+                                    text = tab.label,
+                                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                                )
+                            },
+                            colors = NavigationBarItemDefaults.colors(
+                                selectedIconColor = MaterialTheme.colorScheme.primary,
+                                selectedTextColor = MaterialTheme.colorScheme.primary,
+                                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                            ),
+                        )
+                    }
                 }
             }
         },

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
@@ -3,30 +3,61 @@ package com.bikeprojectminji.bikefront.ui.screen
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
+// GAJA-styled section title with subtitle
 @Composable
-fun SectionTitle(title: String, subtitle: String? = null) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(text = title, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+fun SectionTitle(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
         if (!subtitle.isNullOrBlank()) {
-            Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
 
+// GAJA-styled course card with soft shadows and rounded corners
 @Composable
 fun CourseCard(
     course: CourseCardUiModel,
@@ -36,27 +67,322 @@ fun CourseCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .shadow(
+                elevation = 4.dp,
+                shape = RoundedCornerShape(16.dp),
+                spotColor = Color(0x15000000),
+            )
             .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = course.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                if (course.isRecorded) {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Text(
+                            text = "기록 코스",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                MetricChip(
+                    label = "거리",
+                    value = "%.1f km".format(course.distanceKm),
+                )
+                MetricChip(
+                    label = "예상",
+                    value = "${course.estimatedDurationMin}분",
+                )
+            }
+        }
+    }
+}
+
+// GAJA-styled metric chip
+@Composable
+fun MetricChip(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+// GAJA-styled hero metric card for ride start screen
+@Composable
+fun HeroMetricCard(
+    title: String,
+    value: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary,
+) {
+    Card(
+        modifier = modifier
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(20.dp),
+                spotColor = Color(0x18000000),
+            ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
         shape = RoundedCornerShape(20.dp),
     ) {
-        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Text(text = course.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                if (course.isRecorded) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = accentColor,
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+// GAJA-styled primary action button card
+@Composable
+fun GajaPrimaryCard(
+    title: String,
+    description: String,
+    buttonText: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    gradientColors: List<Color> = listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.tertiary,
+    ),
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 8.dp,
+                shape = RoundedCornerShape(24.dp),
+                spotColor = Color(0x20000000),
+            ),
+        shape = RoundedCornerShape(24.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.horizontalGradient(gradientColors),
+                )
+                .padding(24.dp),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Surface(
+                    onClick = onClick,
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                ) {
                     Text(
-                        text = "기록 코스",
-                        modifier = Modifier
-                            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(999.dp))
-                            .padding(horizontal = 10.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelMedium,
+                        text = buttonText,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                Text(text = "거리 ${"%.1f".format(course.distanceKm)}km", style = MaterialTheme.typography.bodyMedium)
-                Text(text = "예상 ${course.estimatedDurationMin}분", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+// GAJA-styled profile card
+@Composable
+fun ProfileCard(
+    displayName: String,
+    modifier: Modifier = Modifier,
+    onProfileClick: (() -> Unit)? = null,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 4.dp,
+                shape = RoundedCornerShape(20.dp),
+                spotColor = Color(0x12000000),
+            )
+            .then(if (onProfileClick != null) Modifier.clickable(onClick = onProfileClick) else Modifier),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        shape = RoundedCornerShape(20.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Avatar placeholder
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = displayName.firstOrNull()?.uppercase() ?: "?",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
             }
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = displayName,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Text(
+                    text = "탭하여 프로필 관리",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+// GAJA-styled secondary action button
+@Composable
+fun GajaSecondaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        onClick = if (enabled) onClick else ({}),
+        shape = RoundedCornerShape(12.dp),
+        color = if (enabled) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 14.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Medium,
+                color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            )
+        }
+    }
+}
+
+// GAJA-styled outlined button
+@Composable
+fun GajaOutlinedButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        onClick = if (enabled) onClick else ({}),
+        shape = RoundedCornerShape(12.dp),
+        color = Color.Transparent,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 14.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Medium,
+                color = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursePreRideScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursePreRideScreen.kt
@@ -1,16 +1,20 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -24,19 +28,52 @@ fun CoursePreRideScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        SectionTitle(
-            title = "코스 따라가기 준비",
-            subtitle = "선택한 코스를 다시 확인하고 기존 ride 화면으로 진입합니다.",
-        )
-        CourseCard(course = course)
-        Button(onClick = onStartRide, modifier = Modifier.fillMaxWidth()) {
-            Text("이 코스로 시작")
+        // GAJA Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+        ) {
+            Text(
+                text = "코스 따라가기",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
         }
-        OutlinedButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
-            Text("뒤로 가기")
+
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            // Course Info Section
+            SectionTitle(
+                title = "선택한 코스",
+                subtitle = "코스 정보를 확인하고 라이딩을 시작하세요.",
+            )
+
+            // Course Card
+            CourseCard(course = course)
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Action Buttons
+            GajaPrimaryCard(
+                title = "라이딩 시작",
+                description = "이 코스를 따라 라이딩을 시작합니다.",
+                buttonText = "이 코스로 시작",
+                onClick = onStartRide,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            GajaOutlinedButton(
+                text = "뒤로 가기",
+                onClick = onBack,
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesScreen.kt
@@ -1,6 +1,8 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -9,18 +11,21 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
@@ -38,13 +43,13 @@ fun CoursesScreen(
     innerPadding: PaddingValues,
     onOpenCourse: (CourseCardUiModel) -> Unit,
 ) {
-    val context = LocalContext.current
+    val context = androidx.compose.ui.platform.LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val repository = remember(context) { CoursesRepository(context) }
     var selectedTab by remember { mutableStateOf(CourseTab.RECOMMENDED) }
     var refreshKey by remember { mutableStateOf(0) }
 
-    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+    DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 refreshKey++
@@ -67,38 +72,85 @@ fun CoursesScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(horizontal = 20.dp, vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        SectionTitle(title = "코스", subtitle = "추천 코스와 전체 코스를 나눠서 탐색합니다.")
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            CourseTab.entries.forEach { tab ->
-                FilterChip(
-                    selected = selectedTab == tab,
-                    onClick = { selectedTab = tab },
-                    label = { Text(tab.label) },
-                )
-            }
+        // GAJA Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+        ) {
+            Text(
+                text = "코스",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
         }
 
-        val courses = if (selectedTab == CourseTab.RECOMMENDED) featuredState.value else allCoursesState.value?.items.orEmpty()
-        LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            items(courses, key = { it.id }) { course ->
-                CourseCard(course = course, onClick = { onOpenCourse(course) })
-            }
-            if (selectedTab == CourseTab.ALL && allCoursesState.value?.hasNext == true) {
-                item {
-                    OutlinedButton(onClick = { }, enabled = false, modifier = Modifier.fillMaxWidth()) {
-                        Text("추가 코스 불러오기는 아직 연결하지 않았습니다")
-                    }
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            // Tab Chips
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                CourseTab.entries.forEach { tab ->
+                    FilterChip(
+                        selected = selectedTab == tab,
+                        onClick = { selectedTab = tab },
+                        label = {
+                            Text(
+                                text = tab.label,
+                                fontWeight = if (selectedTab == tab) FontWeight.SemiBold else FontWeight.Normal,
+                            )
+                        },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        shape = RoundedCornerShape(12.dp),
+                    )
                 }
             }
+
+            // Course List
+            val courses = if (selectedTab == CourseTab.RECOMMENDED) featuredState.value else allCoursesState.value?.items.orEmpty()
+
             if (courses.isEmpty()) {
-                item {
-                    Text(
-                        text = if (selectedTab == CourseTab.RECOMMENDED) "추천 코스를 준비 중입니다." else "전체 코스를 준비 중입니다.",
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(32.dp),
+                    ) {
+                        Text(
+                            text = if (selectedTab == CourseTab.RECOMMENDED) "추천 코스를 준비 중입니다." else "전체 코스를 준비 중입니다.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(courses, key = { it.id }) { course ->
+                        CourseCard(course = course, onClick = { onOpenCourse(course) })
+                    }
+                    if (selectedTab == CourseTab.ALL && allCoursesState.value?.hasNext == true) {
+                        item {
+                            GajaSecondaryButton(
+                                text = "추가 코스 불러오기는 아직 연결하지 않았습니다",
+                                onClick = { },
+                                enabled = false,
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/FreeRidePreRideScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/FreeRidePreRideScreen.kt
@@ -1,16 +1,33 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -23,21 +40,131 @@ fun FreeRidePreRideScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        SectionTitle(
-            title = "자유 주행 준비",
-            subtitle = "코스 없이 바로 기록하는 모드입니다. 지도/포인터/저장 흐름은 다음 구현 단계에서 연결합니다.",
+        // GAJA Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+        ) {
+            Text(
+                text = "자유 주행 준비",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+        }
+
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            // Info Card
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = 4.dp,
+                        shape = RoundedCornerShape(16.dp),
+                        spotColor = Color(0x15000000),
+                    ),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        text = "자유 주행 모드",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                    Text(
+                        text = "코스 없이 바로 기록하는 모드입니다. 지도/포인터/저장 흐름은 다음 구현 단계에서 연결합니다.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Feature List
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = 2.dp,
+                        shape = RoundedCornerShape(16.dp),
+                        spotColor = Color(0x10000000),
+                    ),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                ),
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    FeatureRow(
+                        icon = Icons.Default.LocationOn,
+                        text = "courseId 없이 시작합니다",
+                    )
+                    FeatureRow(
+                        icon = Icons.Default.CheckCircle,
+                        text = "현재 위치 포인터가 우선이어야 합니다",
+                    )
+                    FeatureRow(
+                        icon = Icons.Default.Save,
+                        text = "종료 후 기록 코스를 전체 코스에 반영하는 흐름으로 이어집니다",
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Action Buttons
+            GajaPrimaryCard(
+                title = "시작 준비",
+                description = "자유 주행을 시작하려면 아래 버튼을 눌러주세요.",
+                buttonText = "자유 주행 시작",
+                onClick = onStartRide,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            GajaOutlinedButton(
+                text = "뒤로 가기",
+                onClick = onBack,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FeatureRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(top = 2.dp),
         )
-        Text("- courseId 없이 시작합니다")
-        Text("- 현재 위치 포인터가 우선이어야 합니다")
-        Text("- 종료 후 기록 코스를 전체 코스에 반영하는 흐름으로 이어집니다")
-        Button(onClick = onStartRide, modifier = Modifier.fillMaxWidth()) {
-            Text("자유 주행 시작")
-        }
-        OutlinedButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
-            Text("뒤로 가기")
-        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
@@ -1,14 +1,16 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -17,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bikeprojectminji.bikefront.auth.AuthSessionStore
 import androidx.compose.ui.platform.LocalContext
@@ -50,16 +53,52 @@ fun MyInfoScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(18.dp),
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        SectionTitle(title = "내 정보", subtitle = "로그인 상태와 추후 기록/설정 진입 영역입니다.")
-        Text(text = displayName, style = MaterialTheme.typography.headlineSmall)
-        Button(onClick = onOpenProfile, modifier = Modifier.fillMaxWidth()) {
-            Text("로그인 / 프로필 열기")
+        // GAJA Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+        ) {
+            Text(
+                text = "내 정보",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
         }
-        OutlinedButton(onClick = { }, enabled = false, modifier = Modifier.fillMaxWidth()) {
-            Text("내 기록 화면은 아직 연결하지 않았습니다")
+
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            // Profile Card
+            ProfileCard(
+                displayName = displayName,
+                onProfileClick = onOpenProfile,
+            )
+
+            // Info Section
+            SectionTitle(
+                title = "계정",
+                subtitle = "로그인 상태와 추후 기록/설정 진입 영역입니다.",
+            )
+
+            // Action Buttons
+            GajaSecondaryButton(
+                text = "로그인 / 프로필 열기",
+                onClick = onOpenProfile,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            GajaOutlinedButton(
+                text = "내 기록 화면은 아직 연결하지 않았습니다",
+                onClick = { },
+                enabled = false,
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
@@ -1,18 +1,21 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -22,7 +25,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
@@ -65,46 +72,96 @@ fun RideStartScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(20.dp)
+            .background(MaterialTheme.colorScheme.background)
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        SectionTitle(
-            title = "라이딩 시작",
-            subtitle = "지금 바로 자유 주행을 시작하거나 추천 코스로 진입하세요.",
-        )
-
-        Card(
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
-            modifier = Modifier.fillMaxWidth(),
+        // GAJA Hero Header Section
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary,
+                            MaterialTheme.colorScheme.tertiary,
+                        ),
+                    ),
+                )
+                .padding(horizontal = 24.dp, vertical = 32.dp),
         ) {
-            Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(text = "자유 주행", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onPrimary)
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 Text(
-                    text = "코스 없이 바로 기록을 시작하는 모드입니다. 현재 구현된 자유 주행 화면으로 바로 진입합니다.",
-                    style = MaterialTheme.typography.bodyMedium,
+                    text = "GAJA",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onPrimary,
                 )
-                Button(onClick = onOpenFreeRide) {
-                    Text("자유 주행 준비 화면 열기")
+                Text(
+                    text = "오늘도 안전하게 라이딩하세요",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            // Free Ride Primary Card
+            GajaPrimaryCard(
+                title = "자유 주행",
+                description = "코스 없이 바로 기록을 시작하는 모드입니다. 현재 위치에서 바로 시작하세요.",
+                buttonText = "자유 주행 시작",
+                onClick = onOpenFreeRide,
+            )
+
+            // Recommended Courses Section
+            SectionTitle(
+                title = "추천 코스",
+                subtitle = "빠르게 바로 탈 수 있는 코스를 먼저 보여줍니다.",
+            )
+
+            if (featuredCourses.value.isEmpty()) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(32.dp),
+                    ) {
+                        Text(
+                            text = "추천 코스를 불러오는 중이거나 아직 준비되지 않았습니다.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    featuredCourses.value.forEach { course ->
+                        CourseCard(course = course, onClick = { onOpenCourse(course) })
+                    }
                 }
             }
-        }
 
-        SectionTitle(title = "추천 코스", subtitle = "빠르게 바로 탈 수 있는 코스를 먼저 보여줍니다.")
-        if (featuredCourses.value.isEmpty()) {
-            Text(text = "추천 코스를 불러오는 중이거나 아직 준비되지 않았습니다.", style = MaterialTheme.typography.bodyMedium)
-        } else {
-            featuredCourses.value.forEach { course ->
-                CourseCard(course = course, onClick = { onOpenCourse(course) })
-            }
-        }
+            // Secondary Actions
+            GajaSecondaryButton(
+                text = "전체 코스 보러 가기",
+                onClick = onOpenCourses,
+            )
 
-        OutlinedButton(onClick = onOpenCourses, modifier = Modifier.fillMaxWidth()) {
-            Text("전체 코스 보러 가기")
-        }
-        OutlinedButton(onClick = onOpenProfile, modifier = Modifier.fillMaxWidth()) {
-            Text("내 정보 / 로그인")
+            GajaOutlinedButton(
+                text = "내 정보 / 로그인",
+                onClick = onOpenProfile,
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
@@ -7,26 +7,86 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
+// GAJA MVP Color Palette - Mint/Teal with White emphasis
+private val GajaMint = Color(0xFF00BFA5) // Primary mint/teal
+private val GajaMintLight = Color(0xFF64FFDA) // Light mint accent
+private val GajaMintDark = Color(0xFF00897B) // Dark mint for emphasis
+
+private val GajaWhite = Color(0xFFFFFFFF) // Pure white
+private val GajaBackground = Color(0xFFF8FAFB) // Soft off-white background
+private val GajaSurface = Color(0xFFFFFFFF) // White surface for cards
+private val GajaSurfaceVariant = Color(0xFFE8F5F3) // Light mint-tinted surface
+
+private val GajaTextPrimary = Color(0xFF1A1A1A) // Near-black for primary text
+private val GajaTextSecondary = Color(0xFF6B7280) // Gray for secondary text
+private val GajaTextTertiary = Color(0xFF9CA3AF) // Light gray for tertiary
+
+private val GajaAccent = Color(0xFF26A69A) // Teal accent
+private val GajaSuccess = Color(0xFF4CAF50) // Green for success states
+private val GajaWarning = Color(0xFFFF9800) // Orange for warnings
+private val GajaError = Color(0xFFE53935) // Red for errors
+
+private val GajaDivider = Color(0xFFE5E7EB) // Light gray for dividers
+private val GajaCardShadow = Color(0x1A000000) // Subtle shadow
+
 private val LightColors = lightColorScheme(
-    primary = Color(0xFF2A8CFF),
-    onPrimary = Color.White,
-    secondary = Color(0xFF132033),
-    background = Color(0xFFF4F7FB),
-    surface = Color.White,
-    onSurface = Color(0xFF111827),
-    surfaceVariant = Color(0xFFE7EEF8),
-    onSurfaceVariant = Color(0xFF4B5563)
+    primary = GajaMint,
+    onPrimary = GajaWhite,
+    primaryContainer = GajaMintLight,
+    onPrimaryContainer = GajaMintDark,
+    
+    secondary = GajaAccent,
+    onSecondary = GajaWhite,
+    secondaryContainer = GajaSurfaceVariant,
+    onSecondaryContainer = GajaTextPrimary,
+    
+    tertiary = GajaMintDark,
+    onTertiary = GajaWhite,
+    
+    background = GajaBackground,
+    onBackground = GajaTextPrimary,
+    
+    surface = GajaSurface,
+    onSurface = GajaTextPrimary,
+    
+    surfaceVariant = GajaSurfaceVariant,
+    onSurfaceVariant = GajaTextSecondary,
+    
+    outline = GajaDivider,
+    outlineVariant = GajaDivider,
+    
+    error = GajaError,
+    onError = GajaWhite,
 )
 
 private val DarkColors = darkColorScheme(
-    primary = Color(0xFF7AB6FF),
-    onPrimary = Color(0xFF05294A),
-    secondary = Color(0xFFD8E6FF),
-    background = Color(0xFF09111C),
-    surface = Color(0xFF101826),
-    onSurface = Color(0xFFF3F7FE),
-    surfaceVariant = Color(0xFF1B2637),
-    onSurfaceVariant = Color(0xFFB4C2D8)
+    primary = GajaMintLight,
+    onPrimary = GajaMintDark,
+    primaryContainer = GajaMintDark,
+    onPrimaryContainer = GajaMintLight,
+    
+    secondary = GajaAccent,
+    onSecondary = GajaWhite,
+    secondaryContainer = Color(0xFF1A3A36),
+    onSecondaryContainer = GajaMintLight,
+    
+    tertiary = GajaMint,
+    onTertiary = GajaMintDark,
+    
+    background = Color(0xFF0D1F1C),
+    onBackground = GajaWhite,
+    
+    surface = Color(0xFF152623),
+    onSurface = GajaWhite,
+    
+    surfaceVariant = Color(0xFF1A3A36),
+    onSurfaceVariant = GajaMintLight,
+    
+    outline = Color(0xFF2D4A45),
+    outlineVariant = Color(0xFF1A3A36),
+    
+    error = Color(0xFFEF5350),
+    onError = Color(0xFF1A0000),
 )
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,9 +64,11 @@
     <string name="ride_map_route_loading_message">경로를 불러오는 중입니다.</string>
     <string name="ride_map_route_error_message">경로를 불러오지 못했습니다.</string>
     <string name="ride_map_route_empty_message">경로 정보가 없습니다.</string>
-    <string name="ride_speed_card_title">속도</string>
+    <string name="ride_speed_card_title">현재 속도</string>
     <string name="ride_speed_loading">--</string>
+    <string name="ride_speed_unit">km/h</string>
     <string name="ride_speed_message_default">현재 속도를 표시합니다.</string>
+    <string name="ride_recording_label">기록 중</string>
     <string name="ride_location_card_title">위치</string>
     <string name="ride_location_loading_value">확인 중</string>
     <string name="ride_location_permission_value">권한 필요</string>


### PR DESCRIPTION
## 요약
- 홈/라이딩 시작, 주행 준비, 전체 코스, 내 정보 화면을 Compose 기준으로 GAJA 민트/화이트 스타일로 재디자인했습니다.
- 공통 테마, 카드/버튼/탭 셸을 함께 정리해 밝은 배경과 라운드 카드 중심의 MVP 톤을 맞췄습니다.
- XML 기반 `RideEntryActivity` 경로는 이번 PR 범위에서 제외하고, Compose 주요 경로를 우선 개선했습니다.

## 검증
- `./gradlew.bat --stop; ./gradlew.bat clean assembleDebug`

## 리뷰 포인트
- 민트/화이트 테마와 카드 스타일이 제공된 레퍼런스 톤과 충분히 비슷한지
- 하단 탭과 상단 브랜드가 Compose 주요 화면 전반에 일관되게 적용됐는지
- XML 경로를 건드리지 않고도 실제 사용자 흐름에서 Compose 경로 개선 효과가 충분한지