### PR TITLE
라이딩 앱 UI를 스포츠 코크핏 톤으로 재설계

### DIFF
--- a/app/src/main/java/com/bikeprojectminji/bikefront/auth/AuthProfileActivity.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/auth/AuthProfileActivity.kt
@@ -4,28 +4,65 @@ import android.app.Activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.text.KeyboardOptions
 import com.bikeprojectminji.bikefront.R
-import com.bikeprojectminji.bikefront.ui.screen.SectionTitle
+import com.bikeprojectminji.bikefront.ui.screen.GajaOutlinedButton
+import com.bikeprojectminji.bikefront.ui.screen.GajaSecondaryButton
 import com.bikeprojectminji.bikefront.ui.theme.BikeFrontTheme
 
 class AuthProfileActivity : ComponentActivity() {
@@ -42,6 +79,7 @@ class AuthProfileActivity : ComponentActivity() {
     private var displayName by mutableStateOf("")
     private var statusMessage by mutableStateOf("")
     private var inFlight by mutableStateOf(false)
+    private var isRegisterMode by mutableStateOf(true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,9 +96,11 @@ class AuthProfileActivity : ComponentActivity() {
                     displayName = displayName,
                     statusMessage = statusMessage,
                     inFlight = inFlight,
+                    isRegisterMode = isRegisterMode,
                     onEmailChange = { email = it },
                     onPasswordChange = { password = it },
                     onDisplayNameChange = { displayName = it },
+                    onToggleMode = { isRegisterMode = !isRegisterMode },
                     onRegister = { submit(isRegister = true) },
                     onLogin = { submit(isRegister = false) },
                     onLater = { finish() },
@@ -112,6 +152,7 @@ class AuthProfileActivity : ComponentActivity() {
 }
 
 @Suppress("LongParameterList")
+@OptIn(ExperimentalMaterial3Api::class)
 @androidx.compose.runtime.Composable
 private fun AuthProfileScreen(
     reason: String,
@@ -120,72 +161,435 @@ private fun AuthProfileScreen(
     displayName: String,
     statusMessage: String,
     inFlight: Boolean,
+    isRegisterMode: Boolean,
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     onDisplayNameChange: (String) -> Unit,
+    onToggleMode: () -> Unit,
     onRegister: () -> Unit,
     onLogin: () -> Unit,
     onLater: () -> Unit,
 ) {
-    Column(
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+    Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "GAJA",
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.inverseSurface,
+                    titleContentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    navigationIconContentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    actionIconContentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                ),
+            )
+        },
+    ) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            // === Hero Section with Strong Visual Hierarchy ===
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.inverseSurface,
+                                MaterialTheme.colorScheme.surfaceContainerHigh,
+                            ),
+                        ),
+                    )
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Surface(
+                        shape = RoundedCornerShape(999.dp),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+                    ) {
+                        Text(
+                            text = if (isRegisterMode) "ACCOUNT SETUP" else "ACCOUNT ACCESS",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+
+                    Text(
+                        text = if (isRegisterMode) "라이딩 기록을 남길 준비를 시작합니다" else "기록을 이어서 주행 흐름으로 복귀합니다",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                    Text(
+                        text = if (reason.isBlank()) {
+                            if (isRegisterMode) "계정을 만들면 주행 저장, 코스 보관, 계정 기반 동기화가 하나의 흐름으로 연결됩니다." else "로그인 후 저장, 코스 작성, 계정 기반 기록 관리를 바로 이어갈 수 있습니다."
+                        } else {
+                            reason
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.82f),
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                // === Mode Toggle ===
+                ModeToggleCard(
+                    isRegisterMode = isRegisterMode,
+                    onToggleMode = onToggleMode,
+                    enabled = !inFlight,
+                )
+
+                // === Form Card ===
+                ElevatedCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(24.dp),
+                    colors = CardDefaults.elevatedCardColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                    elevation = CardDefaults.elevatedCardElevation(
+                        defaultElevation = 2.dp,
+                    ),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(20.dp),
+                    ) {
+                        Text(
+                            text = if (isRegisterMode) "새 계정 만들기" else "계정으로 로그인",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+
+                        // === Email Field ===
+                        AuthInputField(
+                            label = "이메일",
+                            value = email,
+                            placeholder = "example@email.com",
+                            onValueChange = onEmailChange,
+                            keyboardType = KeyboardType.Email,
+                            enabled = !inFlight,
+                        )
+
+                        // === Password Field ===
+                        AuthInputField(
+                            label = "비밀번호",
+                            value = password,
+                            placeholder = "비밀번호를 입력하세요",
+                            onValueChange = onPasswordChange,
+                            password = true,
+                            keyboardType = KeyboardType.Password,
+                            enabled = !inFlight,
+                        )
+
+                        // === Display Name Field (Register only) ===
+                        AnimatedVisibility(
+                            visible = isRegisterMode,
+                            enter = fadeIn(animationSpec = tween(200)) + slideInVertically(),
+                            exit = fadeOut(animationSpec = tween(200)) + slideOutVertically(),
+                        ) {
+                            AuthInputField(
+                                label = "표시 이름",
+                                value = displayName,
+                                placeholder = "예: 한강라이더",
+                                onValueChange = onDisplayNameChange,
+                                keyboardType = KeyboardType.Text,
+                                enabled = !inFlight,
+                            )
+                        }
+                    }
+                }
+
+                // === Status Message ===
+                AnimatedVisibility(
+                    visible = statusMessage.isNotBlank(),
+                    enter = fadeIn(animationSpec = tween(200)) + slideInVertically(),
+                    exit = fadeOut(animationSpec = tween(200)) + slideOutVertically(),
+                ) {
+                    StatusMessageCard(
+                        message = statusMessage,
+                        isError = statusMessage.contains("실패") || statusMessage.contains("오류"),
+                    )
+                }
+
+                // === Loading Indicator ===
+                AnimatedVisibility(
+                    visible = inFlight,
+                    enter = fadeIn(animationSpec = tween(200)),
+                    exit = fadeOut(animationSpec = tween(200)),
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.primary,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Text(
+                            text = "처리 중입니다...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                // === Primary Action Button ===
+                Button(
+                    onClick = if (isRegisterMode) onRegister else onLogin,
+                    enabled = !inFlight,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                        disabledContainerColor = MaterialTheme.colorScheme.outline,
+                        disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    ),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    Text(
+                        text = if (isRegisterMode) "가입하고 계속" else "로그인",
+                        modifier = Modifier.padding(vertical = 6.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+
+                // === Secondary Actions ===
+                if (isRegisterMode) {
+                    GajaSecondaryButton(
+                        text = "기존 계정으로 로그인",
+                        onClick = onToggleMode,
+                        enabled = !inFlight,
+                        icon = "🔐",
+                    )
+                } else {
+                    GajaSecondaryButton(
+                        text = "새 계정 만들기",
+                        onClick = onToggleMode,
+                        enabled = !inFlight,
+                        icon = "✨",
+                    )
+                }
+
+                GajaOutlinedButton(
+                    text = "나중에 할게요",
+                    onClick = onLater,
+                    enabled = !inFlight,
+                    icon = "←",
+                )
+
+                // === Help Section ===
+                HelpSection()
+            }
+        }
+    }
+}
+
+// === Mode Toggle Card ===
+@Composable
+private fun ModeToggleCard(
+    isRegisterMode: Boolean,
+    onToggleMode: () -> Unit,
+    enabled: Boolean,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 1.dp),
     ) {
-        SectionTitle(
-            title = "로그인하고 저장 이어가기",
-            subtitle = if (reason.isBlank()) "로그인 후 저장과 코스 만들기를 이어갈 수 있습니다." else reason,
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = RoundedCornerShape(14.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+            ) {
+                Box(
+                    modifier = Modifier.size(48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = if (isRegisterMode) "01" else "02",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = if (isRegisterMode) "처음 오셨나요?" else "이미 계정이 있으신가요?",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = if (isRegisterMode) "새 계정을 만들어 시작하세요" else "로그인하고 바로 시작하세요",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TextButton(
+                onClick = onToggleMode,
+                enabled = enabled,
+            ) {
+                Text(if (isRegisterMode) "로그인" else "가입")
+            }
+        }
+    }
+}
 
+// === Auth Input Field with Enhanced Readability ===
+@Composable
+private fun AuthInputField(
+    label: String,
+    value: String,
+    placeholder: String,
+    onValueChange: (String) -> Unit,
+    password: Boolean = false,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    enabled: Boolean = true,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
         OutlinedTextField(
-            value = email,
-            onValueChange = onEmailChange,
+            value = value,
+            onValueChange = onValueChange,
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("이메일") },
-            placeholder = { Text("예: bikeoasis@example.com") },
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                )
+            },
             singleLine = true,
-        )
-
-        OutlinedTextField(
-            value = password,
-            onValueChange = onPasswordChange,
-            modifier = Modifier.fillMaxWidth(),
-            label = { Text("비밀번호") },
-            placeholder = { Text("비밀번호를 입력해 주세요") },
-            visualTransformation = PasswordVisualTransformation(),
+            enabled = enabled,
+            textStyle = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Normal,
+            ),
+            visualTransformation = if (password) PasswordVisualTransformation() else VisualTransformation.None,
             keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
+                keyboardType = keyboardType,
                 imeAction = ImeAction.Done,
             ),
-            singleLine = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surface,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                cursorColor = MaterialTheme.colorScheme.primary,
+                focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f),
+                disabledBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                disabledPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+            ),
+            shape = RoundedCornerShape(14.dp),
         )
+    }
+}
 
-        OutlinedTextField(
-            value = displayName,
-            onValueChange = onDisplayNameChange,
-            modifier = Modifier.fillMaxWidth(),
-            label = { Text("표시 이름") },
-            placeholder = { Text("예: 한강라이더") },
-            singleLine = true,
+// === Status Message Card ===
+@Composable
+private fun StatusMessageCard(
+    message: String,
+    isError: Boolean,
+) {
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = if (isError) {
+            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+        } else {
+            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = if (isError) "⚠️" else "✓",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (isError) {
+                    MaterialTheme.colorScheme.onErrorContainer
+                } else {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                },
+            )
+        }
+    }
+}
+
+// === Help Section ===
+@Composable
+private fun HelpSection() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "도움이 필요하신가요?",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
         )
-
-        if (statusMessage.isNotBlank()) {
-            Text(text = statusMessage, style = MaterialTheme.typography.bodyMedium)
-        }
-
-        if (inFlight) {
-            CircularProgressIndicator()
-        }
-
-        Button(onClick = onRegister, enabled = !inFlight, modifier = Modifier.fillMaxWidth()) {
-            Text("가입하고 계속")
-        }
-        OutlinedButton(onClick = onLogin, enabled = !inFlight, modifier = Modifier.fillMaxWidth()) {
-            Text("기존 계정으로 로그인")
-        }
-        OutlinedButton(onClick = onLater, enabled = !inFlight, modifier = Modifier.fillMaxWidth()) {
-            Text("나중에 할게요")
+        TextButton(
+            onClick = { /* TODO: Open help */ },
+        ) {
+            Text(
+                text = "고객센터 문의하기",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/auth/AuthProfileActivity.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/auth/AuthProfileActivity.kt
@@ -60,6 +60,10 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.Icon
 import com.bikeprojectminji.bikefront.R
 import com.bikeprojectminji.bikefront.ui.screen.GajaOutlinedButton
 import com.bikeprojectminji.bikefront.ui.screen.GajaSecondaryButton
@@ -376,27 +380,16 @@ private fun AuthProfileScreen(
 
                 // === Secondary Actions ===
                 if (isRegisterMode) {
-                    GajaSecondaryButton(
-                        text = "기존 계정으로 로그인",
-                        onClick = onToggleMode,
-                        enabled = !inFlight,
-                        icon = "🔐",
-                    )
+                    TextButton(onClick = onToggleMode, enabled = !inFlight, modifier = Modifier.fillMaxWidth()) {
+                        Text("기존 계정으로 로그인")
+                    }
                 } else {
-                    GajaSecondaryButton(
-                        text = "새 계정 만들기",
-                        onClick = onToggleMode,
-                        enabled = !inFlight,
-                        icon = "✨",
-                    )
+                    TextButton(onClick = onToggleMode, enabled = !inFlight, modifier = Modifier.fillMaxWidth()) {
+                        Text("새 계정 만들기")
+                    }
                 }
 
-                GajaOutlinedButton(
-                    text = "나중에 할게요",
-                    onClick = onLater,
-                    enabled = !inFlight,
-                    icon = "←",
-                )
+                GajaOutlinedButton(text = "나중에 할게요", onClick = onLater, enabled = !inFlight)
 
                 // === Help Section ===
                 HelpSection()
@@ -552,9 +545,10 @@ private fun StatusMessageCard(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = if (isError) "⚠️" else "✓",
-                style = MaterialTheme.typography.titleMedium,
+            Icon(
+                imageVector = if (isError) Icons.Outlined.WarningAmber else Icons.Outlined.CheckCircle,
+                contentDescription = null,
+                tint = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
             )
             Text(
                 text = message,

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/FreeRideActivity.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/FreeRideActivity.kt
@@ -826,40 +826,54 @@ private fun RideScreen(
                     }
                 }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small), modifier = Modifier.fillMaxWidth()) {
-                    FloatingHudChip(title = "추적", value = if (isRiding) "기록 중" else "대기", modifier = Modifier.weight(1f))
-                    FloatingHudChip(title = "GPS", value = if (permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null) "연결됨" else "확인 중", modifier = Modifier.weight(1f))
-                }
-
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     color = hudPanelStrongColor,
                     shape = MaterialTheme.shapes.extraLarge,
                     border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
                 ) {
-                    Column(
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = GajaSpacing.CardPadding, vertical = GajaSpacing.Medium),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(
-                            text = if (isRiding) "현재 속도" else "출발 준비",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.labelLarge,
-                        )
-                        Text(
-                            text = if (isRiding) "24.5" else "0.0",
-                            color = MaterialTheme.colorScheme.primary,
-                            style = MaterialTheme.typography.displayLarge,
-                        )
-                        Text(
-                            text = if (isRiding) "km/h" else "km/h 대기",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-                        GpsPill(text = if (permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null) "GPS 신호 양호" else "GPS 확인 중")
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            Text(
+                                text = if (isRiding) "라이딩 진행 중" else "출발 준비",
+                                color = MaterialTheme.colorScheme.inverseOnSurface,
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small)) {
+                                FloatingHudChip(title = "추적", value = if (isRiding) "기록 중" else "대기")
+                                FloatingHudChip(title = "GPS", value = if (permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null) "연결됨" else "확인 중")
+                            }
+                            GpsPill(text = if (permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null) "GPS 신호 양호" else "GPS 확인 중")
+                        }
+                        Column(
+                            horizontalAlignment = Alignment.End,
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            Text(
+                                text = if (isRiding) "속도" else "현재 상태",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                            Text(
+                                text = if (isRiding) "24.5" else "READY",
+                                color = MaterialTheme.colorScheme.primary,
+                                style = if (isRiding) MaterialTheme.typography.displayMedium else MaterialTheme.typography.headlineMedium,
+                            )
+                            Text(
+                                text = if (isRiding) "km/h" else "탭하여 시작",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                        }
                     }
                 }
             }
@@ -897,11 +911,6 @@ private fun RideScreen(
                     }
                 }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small), modifier = Modifier.fillMaxWidth()) {
-                    MinimalHudPanel(modifier = Modifier.weight(1f), title = "날씨", value = weatherSummary)
-                    MinimalHudPanel(modifier = Modifier.weight(1f), title = "정책", value = policySummary)
-                }
-
                 if (!policyBanner.isNullOrBlank()) {
                     Surface(color = MaterialTheme.colorScheme.errorContainer, shape = MaterialTheme.shapes.medium) {
                         Text(
@@ -918,44 +927,53 @@ private fun RideScreen(
                     shape = MaterialTheme.shapes.large,
                     border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
                 ) {
-                    Row(
+                    Column(
                         modifier = Modifier.fillMaxWidth().padding(GajaSpacing.Medium),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        if (!isRiding) {
-                            Button(
-                                onClick = onStartRide,
-                                enabled = permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null,
-                                modifier = Modifier.weight(1f),
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.primary,
-                                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                                ),
-                            ) {
-                                Text(if (rideMode == RideMode.FREE_RIDE) "주행 시작" else "코스 시작")
-                            }
-                        } else {
-                            Button(
-                                onClick = onFinishRide,
-                                modifier = Modifier.weight(1f),
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.tertiary,
-                                    contentColor = MaterialTheme.colorScheme.onTertiary,
-                                ),
-                            ) {
-                                Text("주행 종료")
-                            }
+                        Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small), modifier = Modifier.fillMaxWidth()) {
+                            MinimalHudPanel(modifier = Modifier.weight(1f), title = "날씨", value = weatherSummary)
+                            MinimalHudPanel(modifier = Modifier.weight(1f), title = "정책", value = policySummary)
                         }
-                        OutlinedButton(
-                            onClick = onSaveRecord,
-                            enabled = canSaveRecord,
-                            modifier = Modifier.weight(1f),
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                contentColor = MaterialTheme.colorScheme.inverseOnSurface,
-                            ),
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth(),
                         ) {
-                            Text(if (isSaving) "저장 중" else "기록 저장")
+                            if (!isRiding) {
+                                Button(
+                                    onClick = onStartRide,
+                                    enabled = permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null,
+                                    modifier = Modifier.weight(1f),
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.primary,
+                                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                                    ),
+                                ) {
+                                    Text(if (rideMode == RideMode.FREE_RIDE) "주행 시작" else "코스 시작")
+                                }
+                            } else {
+                                Button(
+                                    onClick = onFinishRide,
+                                    modifier = Modifier.weight(1f),
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.tertiary,
+                                        contentColor = MaterialTheme.colorScheme.onTertiary,
+                                    ),
+                                ) {
+                                    Text("주행 종료")
+                                }
+                            }
+                            OutlinedButton(
+                                onClick = onSaveRecord,
+                                enabled = canSaveRecord,
+                                modifier = Modifier.weight(1f),
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                                ),
+                            ) {
+                                Text(if (isSaving) "저장 중" else "기록 저장")
+                            }
                         }
                     }
                 }
@@ -968,13 +986,16 @@ private fun RideScreen(
 private fun FloatingHudChip(modifier: Modifier = Modifier, title: String, value: String) {
     Surface(
         modifier = modifier,
-        color = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.82f),
-        shape = MaterialTheme.shapes.large,
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.08f)),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.18f),
+        shape = RoundedCornerShape(999.dp),
     ) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(title, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.72f), style = MaterialTheme.typography.labelMedium)
-            Text(value, color = MaterialTheme.colorScheme.inverseOnSurface, style = MaterialTheme.typography.headlineSmall)
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(title, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.72f), style = MaterialTheme.typography.labelSmall)
+            Text(value, color = MaterialTheme.colorScheme.inverseOnSurface, style = MaterialTheme.typography.labelLarge)
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/FreeRideActivity.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/FreeRideActivity.kt
@@ -827,8 +827,8 @@ private fun RideScreen(
                 }
 
                 Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small), modifier = Modifier.fillMaxWidth()) {
-                    FloatingHudChip(title = "풍향", value = "NW", modifier = Modifier.weight(1f))
-                    FloatingHudChip(title = "풍속", value = "12m/s", modifier = Modifier.weight(1f))
+                    FloatingHudChip(title = "추적", value = if (isRiding) "기록 중" else "대기", modifier = Modifier.weight(1f))
+                    FloatingHudChip(title = "GPS", value = if (permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null) "연결됨" else "확인 중", modifier = Modifier.weight(1f))
                 }
 
                 Surface(
@@ -998,7 +998,7 @@ private fun MinimalHudPanel(modifier: Modifier = Modifier, title: String, value:
 private fun GpsPill(text: String) {
     Surface(shape = RoundedCornerShape(999.dp), color = MaterialTheme.colorScheme.primaryContainer) {
         Text(
-            text = "• $text",
+            text = text,
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
             color = MaterialTheme.colorScheme.onPrimaryContainer,
             style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/bikeprojectminji/bikefront/free/FreeRideActivity.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/free/FreeRideActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.MyLocation
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -65,6 +66,7 @@ import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyEvaluationGateway
 import com.bikeprojectminji.bikefront.ridepolicy.RidePolicyUiMapper
 import com.bikeprojectminji.bikefront.ui.model.RideMode
 import com.bikeprojectminji.bikefront.ui.theme.BikeFrontTheme
+import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 import com.bikeprojectminji.bikefront.weather.CurrentWeatherGateway
 import com.bikeprojectminji.bikefront.weather.HttpCurrentWeatherGateway
 import org.maplibre.android.MapLibre
@@ -756,7 +758,10 @@ private fun RideScreen(
     onMapReady: (MapView) -> Unit,
 ) {
     val context = LocalContext.current
-    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF09111C))) {
+    val hudPanelColor = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.80f)
+    val hudPanelStrongColor = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.92f)
+    val hudBorderColor = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.08f)
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.inverseSurface)) {
         AndroidView(
             modifier = Modifier.fillMaxSize(),
             factory = {
@@ -774,73 +779,182 @@ private fun RideScreen(
                 .statusBarsPadding()
                 .safeDrawingPadding()
                 .navigationBarsPadding()
-                .padding(16.dp),
+                .padding(horizontal = GajaSpacing.ScreenPadding, vertical = GajaSpacing.Medium),
             verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Surface(color = Color(0xAA101826), shape = RoundedCornerShape(24.dp)) {
-                    Row(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
-                        IconButton(onClick = onBack) {
-                            Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "뒤로")
+            Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Medium)) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                    Surface(
+                        color = hudPanelColor,
+                        shape = MaterialTheme.shapes.extraLarge,
+                        border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
+                    ) {
+                        Row(modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp), verticalAlignment = Alignment.CenterVertically) {
+                            IconButton(onClick = onBack) {
+                                Icon(
+                                    Icons.AutoMirrored.Outlined.ArrowBack,
+                                    contentDescription = "뒤로",
+                                    tint = MaterialTheme.colorScheme.inverseOnSurface,
+                                )
+                            }
+                            Column(modifier = Modifier.padding(end = GajaSpacing.Medium)) {
+                                Text(
+                                    screenTitle,
+                                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                                    style = MaterialTheme.typography.titleMedium,
+                                )
+                                Text(
+                                    statusMessage,
+                                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.88f),
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            }
                         }
-                        Column(modifier = Modifier.padding(end = 12.dp)) {
-                            Text(screenTitle, color = Color.White, style = MaterialTheme.typography.titleMedium)
-                            Text(statusMessage, color = Color(0xFFD0D5DD), style = MaterialTheme.typography.bodySmall)
+                    }
+                    Surface(
+                        color = hudPanelColor,
+                        shape = CircleShape,
+                        border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
+                    ) {
+                        IconButton(onClick = onCenterMyLocation) {
+                            Icon(
+                                Icons.Outlined.MyLocation,
+                                contentDescription = "내 위치",
+                                tint = MaterialTheme.colorScheme.inverseOnSurface,
+                            )
                         }
                     }
                 }
-                Surface(color = Color(0xAA101826), shape = CircleShape) {
-                    IconButton(onClick = onCenterMyLocation, enabled = latestLocation != null) {
-                        Icon(Icons.Outlined.MyLocation, contentDescription = "내 위치", tint = Color.White)
+
+                Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small), modifier = Modifier.fillMaxWidth()) {
+                    FloatingHudChip(title = "풍향", value = "NW", modifier = Modifier.weight(1f))
+                    FloatingHudChip(title = "풍속", value = "12m/s", modifier = Modifier.weight(1f))
+                }
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = hudPanelStrongColor,
+                    shape = MaterialTheme.shapes.extraLarge,
+                    border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = GajaSpacing.CardPadding, vertical = GajaSpacing.Medium),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(
+                            text = if (isRiding) "현재 속도" else "출발 준비",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Text(
+                            text = if (isRiding) "24.5" else "0.0",
+                            color = MaterialTheme.colorScheme.primary,
+                            style = MaterialTheme.typography.displayLarge,
+                        )
+                        Text(
+                            text = if (isRiding) "km/h" else "km/h 대기",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        GpsPill(text = if (permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null) "GPS 신호 양호" else "GPS 확인 중")
                     }
                 }
             }
 
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Small)) {
                 if (permissionState != FreeRideActivity.PermissionState.GRANTED) {
-                    Card(colors = CardDefaults.cardColors(containerColor = Color(0xCC101826))) {
-                        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text("위치 권한", color = Color.White, style = MaterialTheme.typography.titleMedium)
-                            Text(stringResourceCompat(permissionState.messageRes), color = Color(0xFFD0D5DD))
+                    Surface(
+                        color = hudPanelColor,
+                        shape = MaterialTheme.shapes.large,
+                        border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
+                    ) {
+                        Column(modifier = Modifier.padding(GajaSpacing.Medium), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            Text("위치 권한 필요", color = MaterialTheme.colorScheme.inverseOnSurface, style = MaterialTheme.typography.titleSmall)
+                            Text(
+                                "주행을 시작하려면 위치 권한을 허용해 주세요.",
+                                color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.88f),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
                             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                Button(onClick = onRequestPermission) { Text("권한 요청") }
-                                OutlinedButton(onClick = onOpenSettings) { Text("설정") }
+                                Button(
+                                    onClick = onRequestPermission,
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.primary,
+                                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                                    ),
+                                ) { Text("권한 요청") }
+                                OutlinedButton(
+                                    onClick = onOpenSettings,
+                                    colors = ButtonDefaults.outlinedButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                                    ),
+                                ) { Text("설정 열기") }
                             }
                         }
                     }
                 }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
-                    MiniHudCard(modifier = Modifier.weight(1f), title = "모드", value = if (isRiding) rideMode.name else "대기")
-                    MiniHudCard(modifier = Modifier.weight(1f), title = "날씨", value = weatherSummary)
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
-                    MiniHudCard(
-                        modifier = Modifier.weight(1f),
-                        title = "위치",
-                        value = latestLocation?.let { "${it.latitude.format(4)}, ${it.longitude.format(4)}" } ?: "대기 중",
-                    )
-                    MiniHudCard(modifier = Modifier.weight(1f), title = "정책", value = policySummary)
+                Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small), modifier = Modifier.fillMaxWidth()) {
+                    MinimalHudPanel(modifier = Modifier.weight(1f), title = "날씨", value = weatherSummary)
+                    MinimalHudPanel(modifier = Modifier.weight(1f), title = "정책", value = policySummary)
                 }
 
                 if (!policyBanner.isNullOrBlank()) {
-                    Card(colors = CardDefaults.cardColors(containerColor = Color(0xCCFEE4E2))) {
-                        Text(text = policyBanner, modifier = Modifier.padding(14.dp), color = Color(0xFFB42318))
+                    Surface(color = MaterialTheme.colorScheme.errorContainer, shape = MaterialTheme.shapes.medium) {
+                        Text(
+                            text = policyBanner,
+                            modifier = Modifier.padding(14.dp),
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
                     }
                 }
 
-                Card(colors = CardDefaults.cardColors(containerColor = Color(0xCC101826))) {
-                    Row(modifier = Modifier.fillMaxWidth().padding(16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Surface(
+                    color = hudPanelStrongColor,
+                    shape = MaterialTheme.shapes.large,
+                    border = androidx.compose.foundation.BorderStroke(1.dp, hudBorderColor),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(GajaSpacing.Medium),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         if (!isRiding) {
-                            Button(onClick = onStartRide, enabled = permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null, modifier = Modifier.weight(1f)) {
-                                Text(if (rideMode == RideMode.FREE_RIDE) "자유 주행 시작" else "코스 주행 시작")
+                            Button(
+                                onClick = onStartRide,
+                                enabled = permissionState == FreeRideActivity.PermissionState.GRANTED && latestLocation != null,
+                                modifier = Modifier.weight(1f),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                                ),
+                            ) {
+                                Text(if (rideMode == RideMode.FREE_RIDE) "주행 시작" else "코스 시작")
                             }
                         } else {
-                            Button(onClick = onFinishRide, modifier = Modifier.weight(1f)) {
+                            Button(
+                                onClick = onFinishRide,
+                                modifier = Modifier.weight(1f),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.tertiary,
+                                    contentColor = MaterialTheme.colorScheme.onTertiary,
+                                ),
+                            ) {
                                 Text("주행 종료")
                             }
                         }
-                        OutlinedButton(onClick = onSaveRecord, enabled = canSaveRecord, modifier = Modifier.weight(1f)) {
+                        OutlinedButton(
+                            onClick = onSaveRecord,
+                            enabled = canSaveRecord,
+                            modifier = Modifier.weight(1f),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                            ),
+                        ) {
                             Text(if (isSaving) "저장 중" else "기록 저장")
                         }
                     }
@@ -851,12 +965,44 @@ private fun RideScreen(
 }
 
 @Composable
-private fun MiniHudCard(modifier: Modifier = Modifier, title: String, value: String) {
-    Card(modifier = modifier, colors = CardDefaults.cardColors(containerColor = Color(0xB3101826))) {
-        Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            Text(title, color = Color(0xFFD0D5DD), style = MaterialTheme.typography.labelMedium)
-            Text(value, color = Color.White, style = MaterialTheme.typography.bodyMedium)
+private fun FloatingHudChip(modifier: Modifier = Modifier, title: String, value: String) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.82f),
+        shape = MaterialTheme.shapes.large,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.08f)),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(title, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.72f), style = MaterialTheme.typography.labelMedium)
+            Text(value, color = MaterialTheme.colorScheme.inverseOnSurface, style = MaterialTheme.typography.headlineSmall)
         }
+    }
+}
+
+@Composable
+private fun MinimalHudPanel(modifier: Modifier = Modifier, title: String, value: String) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.80f),
+        shape = MaterialTheme.shapes.medium,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.08f)),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(title, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.88f), style = MaterialTheme.typography.labelMedium)
+            Text(value, color = MaterialTheme.colorScheme.inverseOnSurface, style = MaterialTheme.typography.titleSmall)
+        }
+    }
+}
+
+@Composable
+private fun GpsPill(text: String) {
+    Surface(shape = RoundedCornerShape(999.dp), color = MaterialTheme.colorScheme.primaryContainer) {
+        Text(
+            text = "• $text",
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            style = MaterialTheme.typography.labelMedium,
+        )
     }
 }
 

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/BikeFrontApp.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/BikeFrontApp.kt
@@ -2,20 +2,11 @@ package com.bikeprojectminji.bikefront.ui
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.DirectionsBike
-import androidx.compose.material.icons.automirrored.outlined.ListAlt
-import androidx.compose.material.icons.filled.DirectionsBike
-import androidx.compose.material.icons.filled.ListAlt
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.outlined.PersonOutline
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -30,13 +21,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.outlined.DirectionsBike
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.automirrored.outlined.List
+import androidx.compose.material.icons.outlined.PersonOutline
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -49,7 +46,16 @@ import com.bikeprojectminji.bikefront.ui.screen.CourseCardUiModel
 import com.bikeprojectminji.bikefront.ui.screen.FreeRidePreRideScreen
 import com.bikeprojectminji.bikefront.ui.screen.MyInfoScreen
 import com.bikeprojectminji.bikefront.ui.screen.RideStartScreen
+import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 
+// ============================================================================
+// GAJA App Shell - Material 3 Navigation
+// Main navigation structure with bottom navigation bar
+// ============================================================================
+
+/**
+ * Navigation tab definition with Material Icons
+ */
 private enum class MainTab(
     val route: String,
     val label: String,
@@ -59,14 +65,14 @@ private enum class MainTab(
     RIDE_START(
         route = "ride_start",
         label = "라이딩",
-        selectedIcon = Icons.Filled.DirectionsBike,
+        selectedIcon = Icons.AutoMirrored.Filled.DirectionsBike,
         unselectedIcon = Icons.AutoMirrored.Outlined.DirectionsBike,
     ),
     COURSES(
         route = "courses",
         label = "코스",
-        selectedIcon = Icons.Filled.ListAlt,
-        unselectedIcon = Icons.AutoMirrored.Outlined.ListAlt,
+        selectedIcon = Icons.AutoMirrored.Filled.List,
+        unselectedIcon = Icons.AutoMirrored.Outlined.List,
     ),
     MY_INFO(
         route = "my_info",
@@ -76,6 +82,9 @@ private enum class MainTab(
     ),
 }
 
+/**
+ * Navigation routes for detail screens
+ */
 private object Routes {
     const val FREE_RIDE_PRE_RIDE = "free_ride_pre_ride"
     const val COURSE_PRE_RIDE = "course_pre_ride/{courseId}/{title}/{distanceKm}/{durationMin}"
@@ -85,6 +94,10 @@ private object Routes {
     }
 }
 
+/**
+ * Main app composable with Material 3 navigation shell.
+ * Provides bottom navigation and navigation host for all screens.
+ */
 @Composable
 fun BikeFrontApp() {
     val navController = rememberNavController()
@@ -97,20 +110,26 @@ fun BikeFrontApp() {
         modifier = Modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.background,
         bottomBar = {
-            // GAJA-styled bottom navigation with shadow
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(
+                        start = GajaSpacing.Large,
+                        end = GajaSpacing.Large,
+                        top = 4.dp,
+                        bottom = GajaSpacing.ExtraSmall,
+                    )
                     .shadow(
                         elevation = 16.dp,
-                        spotColor = Color(0x15000000),
+                        spotColor = Color(0x14000000),
                     ),
+                shape = MaterialTheme.shapes.large,
                 color = MaterialTheme.colorScheme.surface,
             ) {
                 NavigationBar(
-                    containerColor = MaterialTheme.colorScheme.surface,
+                    containerColor = Color.Transparent,
                     tonalElevation = 0.dp,
-                    modifier = Modifier.height(72.dp),
+                    modifier = Modifier.height(78.dp),
                 ) {
                     tabs.forEach { tab ->
                         val selected = currentRoute == tab.route
@@ -129,13 +148,13 @@ fun BikeFrontApp() {
                                 Icon(
                                     imageVector = if (selected) tab.selectedIcon else tab.unselectedIcon,
                                     contentDescription = tab.label,
-                                    modifier = Modifier.size(26.dp),
+                                    modifier = Modifier.size(24.dp),
                                 )
                             },
                             label = {
                                 Text(
                                     text = tab.label,
-                                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                                    fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
                                 )
                             },
                             colors = NavigationBarItemDefaults.colors(
@@ -143,7 +162,7 @@ fun BikeFrontApp() {
                                 selectedTextColor = MaterialTheme.colorScheme.primary,
                                 unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                 unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                                indicatorColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
                             ),
                         )
                     }
@@ -159,12 +178,8 @@ fun BikeFrontApp() {
             composable(MainTab.RIDE_START.route) {
                 RideStartScreen(
                     innerPadding = innerPadding,
-                    onOpenFreeRide = { navController.navigate(Routes.FREE_RIDE_PRE_RIDE) },
+                    onStartFreeRide = { navController.navigate(Routes.FREE_RIDE_PRE_RIDE) },
                     onOpenCourse = { navController.navigate(Routes.coursePreRide(it)) },
-                    onOpenCourses = { navController.navigate(MainTab.COURSES.route) },
-                    onOpenProfile = {
-                        context.startActivity(Intent(context, AuthProfileActivity::class.java))
-                    },
                 )
             }
             composable(MainTab.COURSES.route) {

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/BikeFrontApp.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/BikeFrontApp.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -18,7 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material.icons.Icons
@@ -46,7 +45,6 @@ import com.bikeprojectminji.bikefront.ui.screen.CourseCardUiModel
 import com.bikeprojectminji.bikefront.ui.screen.FreeRidePreRideScreen
 import com.bikeprojectminji.bikefront.ui.screen.MyInfoScreen
 import com.bikeprojectminji.bikefront.ui.screen.RideStartScreen
-import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 
 // ============================================================================
 // GAJA App Shell - Material 3 Navigation
@@ -111,25 +109,14 @@ fun BikeFrontApp() {
         containerColor = MaterialTheme.colorScheme.background,
         bottomBar = {
             Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = GajaSpacing.Large,
-                        end = GajaSpacing.Large,
-                        top = 4.dp,
-                        bottom = GajaSpacing.ExtraSmall,
-                    )
-                    .shadow(
-                        elevation = 16.dp,
-                        spotColor = Color(0x14000000),
-                    ),
-                shape = MaterialTheme.shapes.large,
+                modifier = Modifier.fillMaxWidth(),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
                 color = MaterialTheme.colorScheme.surface,
             ) {
                 NavigationBar(
                     containerColor = Color.Transparent,
                     tonalElevation = 0.dp,
-                    modifier = Modifier.height(78.dp),
+                    modifier = Modifier.height(72.dp),
                 ) {
                     tabs.forEach { tab ->
                         val selected = currentRoute == tab.route

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -47,12 +48,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bikeprojectminji.bikefront.ui.theme.GajaDimensions
 import com.bikeprojectminji.bikefront.ui.theme.GajaElevation
+import com.bikeprojectminji.bikefront.ui.theme.GajaIconTokens
 import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 
 // ============================================================================
@@ -259,48 +262,72 @@ fun HeroCard(
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
-            containerColor = Color.Transparent,
+            containerColor = MaterialTheme.colorScheme.inverseSurface,
         ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f)),
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(Brush.horizontalGradient(gradientColors))
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            gradientColors.firstOrNull() ?: MaterialTheme.colorScheme.inverseSurface,
+                            gradientColors.lastOrNull() ?: MaterialTheme.colorScheme.surfaceContainerHigh,
+                        ),
+                    ),
+                )
                 .padding(GajaSpacing.CardPadding),
         ) {
             Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(18.dp),
             ) {
-                if (icon != null) {
-                    Text(
-                        text = icon,
-                        style = MaterialTheme.typography.headlineLarge,
-                    )
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = GajaIconTokens.Ride,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Text(
+                            text = icon ?: "GAJA RIDE",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.headlineSmall,
+                    style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
                 )
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.92f),
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.78f),
                 )
-                Spacer(modifier = Modifier.height(8.dp))
                 FilledTonalButton(
                     onClick = onClick,
-                    shape = MaterialTheme.shapes.medium,
+                    shape = RoundedCornerShape(18.dp),
                     colors = ButtonDefaults.filledTonalButtonColors(
-                        containerColor = MaterialTheme.colorScheme.inverseSurface,
-                        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
                     ),
                 ) {
                     Text(
                         text = buttonText,
                         style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
+                        fontWeight = FontWeight.Bold,
                     )
                 }
             }
@@ -333,7 +360,7 @@ fun BikeSurfaceCard(
     onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    ElevatedCard(
+    Card(
         modifier = modifier
             .fillMaxWidth()
             .then(
@@ -344,12 +371,10 @@ fun BikeSurfaceCard(
                 }
             ),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
         ),
-        elevation = CardDefaults.elevatedCardElevation(
-            defaultElevation = GajaElevation.Medium,
-        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f)),
         content = content,
     )
 }
@@ -364,17 +389,13 @@ fun CourseCard(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
-    ElevatedCard(
+    Card(
         modifier = modifier
             .fillMaxWidth()
             .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        ),
-        elevation = CardDefaults.elevatedCardElevation(
-            defaultElevation = GajaElevation.Medium,
-        ),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Column(
             modifier = Modifier.padding(20.dp),
@@ -419,12 +440,10 @@ fun CourseCard(
                 MetricChip(
                     label = "거리",
                     value = "%.1f km".format(course.distanceKm),
-                    icon = "\uD83D\uDCCD", // 📍
                 )
                 MetricChip(
                     label = "예상",
                     value = "${course.estimatedDurationMin}분",
-                    icon = "\u23F1", // ⏱
                 )
             }
         }
@@ -530,10 +549,19 @@ fun FeatureCard(
                     horizontalArrangement = Arrangement.spacedBy(14.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = feature.icon,
-                        style = MaterialTheme.typography.titleLarge,
-                    )
+                    if (feature.icon.isNotBlank()) {
+                        Text(
+                            text = feature.icon,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.primary),
+                        )
+                    }
                     Text(
                         text = feature.text,
                         style = MaterialTheme.typography.bodyMedium,
@@ -842,7 +870,7 @@ fun ErrorStateView(
     message: String,
     modifier: Modifier = Modifier,
     title: String = "오류가 발생했습니다",
-    icon: String = "\u26A0\uFE0F", // ⚠️
+    icon: String = "",
     onRetry: (() -> Unit)? = null,
 ) {
     Surface(
@@ -857,10 +885,12 @@ fun ErrorStateView(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = icon,
-                style = MaterialTheme.typography.displaySmall,
-            )
+            if (icon.isNotBlank()) {
+                Text(
+                    text = icon,
+                    style = MaterialTheme.typography.displaySmall,
+                )
+            }
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleMedium,
@@ -906,8 +936,9 @@ fun MetricChip(
 ) {
     Surface(
         modifier = modifier,
-        shape = MaterialTheme.shapes.small,
-        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.72f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
@@ -915,10 +946,21 @@ fun MetricChip(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (icon != null) {
-                Text(
-                    text = icon,
-                    style = MaterialTheme.typography.bodyMedium,
-                )
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+                ) {
+                    Box(
+                        modifier = Modifier.size(22.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = icon,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
             }
             Column(
                 verticalArrangement = Arrangement.spacedBy(2.dp),
@@ -1123,7 +1165,7 @@ private fun ProfileStatCard(
                 text = value,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary,
+                color = MaterialTheme.colorScheme.onSurface,
             )
         }
     }
@@ -1253,19 +1295,14 @@ fun GajaBrandTopBar(
                     color = MaterialTheme.colorScheme.primaryContainer,
                 ) {
                     Text(
-                        text = "GAJA RIDE",
+                        text = "GAJA",
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                         style = MaterialTheme.typography.labelMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                 }
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                Text(text = title, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
                 if (!subtitle.isNullOrBlank()) {
                     Text(
                         text = subtitle,

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
@@ -1,12 +1,18 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -14,194 +20,295 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.bikeprojectminji.bikefront.ui.theme.GajaDimensions
+import com.bikeprojectminji.bikefront.ui.theme.GajaElevation
+import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 
-// GAJA-styled section title with subtitle
+// ============================================================================
+// GAJA Material 3 Component Library
+// Reusable components built on Material 3 foundations
+// ============================================================================
+
+// ============================================================================
+// SECTION 1: SCREEN SCAFFOLD
+// Standard screen layout with optional TopAppBar
+// ============================================================================
+
+/**
+ * Standard screen scaffold with consistent padding and optional TopAppBar.
+ * Use this for all main screens to ensure consistent layout.
+ * 
+ * @param title TopAppBar title (shows TopAppBar if provided)
+ * @param subtitle Optional subtitle below title
+ * @param navigationIcon Optional navigation icon
+ * @param actions Optional action icons in TopAppBar
+ * @param useGradientHeader Whether to use gradient header background
+ * @param content Main screen content
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppScreenScaffold(
+    title: String? = null,
+    subtitle: String? = null,
+    navigationIcon: @Composable (() -> Unit)? = null,
+    actions: @Composable (() -> Unit)? = null,
+    useGradientHeader: Boolean = false,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    if (title != null) {
+        Scaffold(
+            containerColor = MaterialTheme.colorScheme.background,
+            topBar = {
+                if (useGradientHeader) {
+                    // Gradient header for hero sections
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        MaterialTheme.colorScheme.primary,
+                                        MaterialTheme.colorScheme.tertiary,
+                                    ),
+                                ),
+                            )
+                            .padding(
+                                horizontal = GajaSpacing.CardPadding,
+                                vertical = GajaSpacing.ScreenPadding,
+                            ),
+                    ) {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = title,
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                            if (!subtitle.isNullOrBlank()) {
+                                Text(
+                                    text = subtitle,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.92f),
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    TopAppBar(
+                        title = {
+                            Column {
+                                Text(
+                                    text = title,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                                if (!subtitle.isNullOrBlank()) {
+                                    Text(
+                                        text = subtitle,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        },
+                        navigationIcon = {
+                            if (navigationIcon != null) {
+                                navigationIcon()
+                            }
+                        },
+                        actions = {
+                            if (actions != null) {
+                                actions()
+                            }
+                        },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                            navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                            actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                    )
+                }
+            },
+        ) { innerPadding ->
+            content(innerPadding)
+        }
+    } else {
+        Scaffold(
+            containerColor = MaterialTheme.colorScheme.background,
+        ) { innerPadding ->
+            content(innerPadding)
+        }
+    }
+}
+
+// ============================================================================
+// SECTION 2: SECTION HEADERS
+// Consistent section headers with optional actions
+// ============================================================================
+
+/**
+ * Section header with title, optional subtitle, and optional action.
+ * Use for dividing content into logical sections.
+ */
+@Composable
+fun AppSectionHeader(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+    action: @Composable (() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        action?.invoke()
+    }
+}
+
+/** Legacy alias for backward compatibility */
+@Composable
+fun SectionHeader(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+    action: @Composable (() -> Unit)? = null,
+) = AppSectionHeader(title, subtitle, modifier, action)
+
 @Composable
 fun SectionTitle(
     title: String,
     subtitle: String? = null,
     modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
-        if (!subtitle.isNullOrBlank()) {
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
+) = AppSectionHeader(title, subtitle, modifier)
 
-// GAJA-styled course card with soft shadows and rounded corners
-@Composable
-fun CourseCard(
-    course: CourseCardUiModel,
-    modifier: Modifier = Modifier,
-    onClick: (() -> Unit)? = null,
-) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 4.dp,
-                shape = RoundedCornerShape(16.dp),
-                spotColor = Color(0x15000000),
-            )
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-        ),
-        shape = RoundedCornerShape(16.dp),
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = course.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onBackground,
-                )
-                if (course.isRecorded) {
-                    Surface(
-                        shape = RoundedCornerShape(12.dp),
-                        color = MaterialTheme.colorScheme.primaryContainer,
-                    ) {
-                        Text(
-                            text = "기록 코스",
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            fontWeight = FontWeight.Medium,
-                        )
-                    }
-                }
-            }
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(20.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                MetricChip(
-                    label = "거리",
-                    value = "%.1f km".format(course.distanceKm),
-                )
-                MetricChip(
-                    label = "예상",
-                    value = "${course.estimatedDurationMin}분",
-                )
-            }
-        }
-    }
-}
+// ============================================================================
+// SECTION 3: CARDS
+// Card variants for different content types
+// ============================================================================
 
-// GAJA-styled metric chip
+/**
+ * Hero card with gradient background for prominent CTAs.
+ * Use for primary actions and featured content.
+ */
 @Composable
-fun MetricChip(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.primary,
-        )
-    }
-}
-
-// GAJA-styled hero metric card for ride start screen
-@Composable
-fun HeroMetricCard(
+fun HeroCard(
     title: String,
-    value: String,
-    subtitle: String? = null,
+    description: String,
+    buttonText: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    accentColor: Color = MaterialTheme.colorScheme.primary,
+    icon: String? = null,
+    gradientColors: List<Color> = listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.tertiary,
+    ),
 ) {
     Card(
-        modifier = modifier
-            .shadow(
-                elevation = 6.dp,
-                shape = RoundedCornerShape(20.dp),
-                spotColor = Color(0x18000000),
-            ),
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = Color.Transparent,
         ),
-        shape = RoundedCornerShape(20.dp),
     ) {
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+                .background(Brush.horizontalGradient(gradientColors))
+                .padding(GajaSpacing.CardPadding),
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = value,
-                style = MaterialTheme.typography.headlineLarge,
-                fontWeight = FontWeight.Bold,
-                color = accentColor,
-            )
-            if (!subtitle.isNullOrBlank()) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                if (icon != null) {
+                    Text(
+                        text = icon,
+                        style = MaterialTheme.typography.headlineLarge,
+                    )
+                }
                 Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary,
                 )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.92f),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                FilledTonalButton(
+                    onClick = onClick,
+                    shape = MaterialTheme.shapes.medium,
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.inverseSurface,
+                        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    ),
+                ) {
+                    Text(
+                        text = buttonText,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
             }
         }
     }
 }
 
-// GAJA-styled primary action button card
+/** Legacy alias */
 @Composable
 fun GajaPrimaryCard(
     title: String,
@@ -213,78 +320,138 @@ fun GajaPrimaryCard(
         MaterialTheme.colorScheme.primary,
         MaterialTheme.colorScheme.tertiary,
     ),
+    icon: String? = null,
+) = HeroCard(title, description, buttonText, onClick, modifier, icon, gradientColors)
+
+/**
+ * Standard surface card for content containers.
+ * Use for most card-based content.
+ */
+@Composable
+fun BikeSurfaceCard(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
-    Card(
+    ElevatedCard(
         modifier = modifier
             .fillMaxWidth()
-            .shadow(
-                elevation = 8.dp,
-                shape = RoundedCornerShape(24.dp),
-                spotColor = Color(0x20000000),
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(onClick = onClick)
+                } else {
+                    Modifier
+                }
             ),
-        shape = RoundedCornerShape(24.dp),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = GajaElevation.Medium,
+        ),
+        content = content,
+    )
+}
+
+/**
+ * Course card for displaying course information.
+ * Standard card for course list items.
+ */
+@Composable
+fun CourseCard(
+    course: CourseCardUiModel,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = GajaElevation.Medium,
+        ),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    Brush.horizontalGradient(gradientColors),
-                )
-                .padding(24.dp),
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+            // Title Row with Badge
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    text = course.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Surface(
-                    onClick = onClick,
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                ) {
-                    Text(
-                        text = buttonText,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                if (course.isRecorded) {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Text(
+                            text = "기록",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
                 }
+            }
+            
+            // Metrics Row
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                MetricChip(
+                    label = "거리",
+                    value = "%.1f km".format(course.distanceKm),
+                    icon = "\uD83D\uDCCD", // 📍
+                )
+                MetricChip(
+                    label = "예상",
+                    value = "${course.estimatedDurationMin}분",
+                    icon = "\u23F1", // ⏱
+                )
             }
         }
     }
 }
 
-// GAJA-styled profile card
+/**
+ * Info card for displaying information with icon.
+ * Use for tips, status, or informational content.
+ */
 @Composable
-fun ProfileCard(
-    displayName: String,
+fun InfoCard(
+    title: String,
+    description: String,
     modifier: Modifier = Modifier,
-    onProfileClick: (() -> Unit)? = null,
+    icon: String? = null,
+    accentColor: Color = MaterialTheme.colorScheme.primary,
 ) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 4.dp,
-                shape = RoundedCornerShape(20.dp),
-                spotColor = Color(0x12000000),
-            )
-            .then(if (onProfileClick != null) Modifier.clickable(onClick = onProfileClick) else Modifier),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
         ),
-        shape = RoundedCornerShape(20.dp),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 4.dp,
+        ),
     ) {
         Row(
             modifier = Modifier
@@ -293,33 +460,34 @@ fun ProfileCard(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Avatar placeholder
-            Box(
-                modifier = Modifier
-                    .size(56.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = displayName.firstOrNull()?.uppercase() ?: "?",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                )
+            if (icon != null) {
+                Surface(
+                    shape = RoundedCornerShape(14.dp),
+                    color = accentColor.copy(alpha = 0.12f),
+                ) {
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = icon,
+                            style = MaterialTheme.typography.headlineSmall,
+                        )
+                    }
+                }
             }
             Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
                 Text(
-                    text = displayName,
-                    style = MaterialTheme.typography.titleLarge,
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
-                    text = "탭하여 프로필 관리",
-                    style = MaterialTheme.typography.bodySmall,
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
@@ -327,62 +495,795 @@ fun ProfileCard(
     }
 }
 
-// GAJA-styled secondary action button
+/** Legacy alias */
+@Composable
+fun GajaInfoCard(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier,
+    icon: String? = null,
+    accentColor: Color = MaterialTheme.colorScheme.primary,
+) = InfoCard(title, description, modifier, icon, accentColor)
+
+/**
+ * Feature card for displaying feature lists.
+ * Use for onboarding or feature highlights.
+ */
+@Composable
+fun FeatureCard(
+    features: List<FeatureItem>,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            features.forEach { feature ->
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = feature.icon,
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+                    Text(
+                        text = feature.text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Legacy alias */
+@Composable
+fun GajaFeatureCard(
+    features: List<FeatureItem>,
+    modifier: Modifier = Modifier,
+) = FeatureCard(features, modifier)
+
+data class FeatureItem(
+    val icon: String,
+    val text: String,
+)
+
+// ============================================================================
+// SECTION 4: BUTTONS
+// Button variants for different actions
+// ============================================================================
+
+/**
+ * Primary action button - filled style.
+ * Use for main CTAs and primary actions.
+ */
+@Composable
+fun PrimaryActionButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth().height(GajaDimensions.ButtonHeight),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+        ),
+    ) {
+        if (icon != null) {
+            androidx.compose.material3.Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+/**
+ * Secondary action button - tonal style.
+ * Use for secondary actions and alternative options.
+ */
+@Composable
+fun SecondaryActionButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+) {
+    FilledTonalButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth().height(GajaDimensions.ButtonHeight),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+        colors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        if (icon != null) {
+            androidx.compose.material3.Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+/**
+ * Tertiary action button - outlined style.
+ * Use for tertiary actions and less prominent options.
+ */
+@Composable
+fun TertiaryActionButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth().height(GajaDimensions.ButtonHeight),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        if (icon != null) {
+            androidx.compose.material3.Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+/** Legacy emoji-based buttons for backward compatibility */
 @Composable
 fun GajaSecondaryButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    icon: String? = null,
 ) {
-    Surface(
+    FilledTonalButton(
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
-        onClick = if (enabled) onClick else ({}),
-        shape = RoundedCornerShape(12.dp),
-        color = if (enabled) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+        colors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 14.dp),
-            contentAlignment = Alignment.Center,
-        ) {
+        if (icon != null) {
             Text(
-                text = text,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Medium,
-                color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                text = icon,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(end = 8.dp),
             )
         }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
     }
 }
 
-// GAJA-styled outlined button
 @Composable
 fun GajaOutlinedButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    icon: String? = null,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        if (icon != null) {
+            Text(
+                text = icon,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(end = 8.dp),
+            )
+        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+// ============================================================================
+// SECTION 5: STATE VIEWS
+// Empty, loading, and error states
+// ============================================================================
+
+/**
+ * Empty state view for when there's no content.
+ * Use for empty lists, no results, etc.
+ */
+@Composable
+fun EmptyStateView(
+    message: String,
+    modifier: Modifier = Modifier,
+    icon: String? = null,
+    title: String? = null,
+    action: @Composable (() -> Unit)? = null,
 ) {
     Surface(
         modifier = modifier.fillMaxWidth(),
-        onClick = if (enabled) onClick else ({}),
-        shape = RoundedCornerShape(12.dp),
-        color = Color.Transparent,
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
     ) {
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 14.dp),
-            contentAlignment = Alignment.Center,
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (icon != null) {
+                Text(
+                    text = icon,
+                    style = MaterialTheme.typography.displaySmall,
+                )
+            }
+            if (!title.isNullOrBlank()) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            action?.invoke()
+        }
+    }
+}
+
+/** Legacy alias */
+@Composable
+fun GajaEmptyState(
+    message: String,
+    modifier: Modifier = Modifier,
+    icon: String? = null,
+) = EmptyStateView(message, modifier, icon)
+
+/**
+ * Loading state view with progress indicator.
+ * Use for loading states and async operations.
+ */
+@Composable
+fun LoadingStateView(
+    message: String = "로딩 중...",
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(48.dp),
+                color = MaterialTheme.colorScheme.primary,
+                strokeWidth = 4.dp,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/**
+ * Error state view for error conditions.
+ * Use for error states with retry option.
+ */
+@Composable
+fun ErrorStateView(
+    message: String,
+    modifier: Modifier = Modifier,
+    title: String = "오류가 발생했습니다",
+    icon: String = "\u26A0\uFE0F", // ⚠️
+    onRetry: (() -> Unit)? = null,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
-                text = text,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Medium,
-                color = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                text = icon,
+                style = MaterialTheme.typography.displaySmall,
             )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            if (onRetry != null) {
+                TextButton(
+                    onClick = onRetry,
+                ) {
+                    Text(
+                        text = "다시 시도",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// SECTION 6: METRIC CHIPS
+// Compact metric displays
+// ============================================================================
+
+/**
+ * Metric chip for displaying key metrics.
+ * Use for distance, time, speed, etc.
+ */
+@Composable
+fun MetricChip(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    icon: String? = null,
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (icon != null) {
+                Text(
+                    text = icon,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Hero metric card for prominent metric display.
+ * Use for dashboard stats and key metrics.
+ */
+@Composable
+fun HeroMetricCard(
+    title: String,
+    value: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary,
+    icon: String? = null,
+) {
+    ElevatedCard(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 4.dp,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (icon != null) {
+                Text(
+                    text = icon,
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Bold,
+                color = accentColor,
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+// ============================================================================
+// SECTION 7: PROFILE COMPONENTS
+// User profile related components
+// ============================================================================
+
+/**
+ * Profile hero card for user profile display.
+ * Use for profile sections and user info.
+ */
+@Composable
+fun ProfileHeroCard(
+    displayName: String,
+    modifier: Modifier = Modifier,
+    onProfileClick: (() -> Unit)? = null,
+    stats: List<ProfileStat>? = null,
+) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (onProfileClick != null) Modifier.clickable(onClick = onProfileClick) else Modifier),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 2.dp,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            // Avatar Row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(18.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Avatar Circle with gradient
+                Box(
+                    modifier = Modifier
+                        .size(72.dp)
+                        .clip(CircleShape)
+                        .background(
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    MaterialTheme.colorScheme.primary,
+                                    MaterialTheme.colorScheme.tertiary,
+                                ),
+                            ),
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = displayName.firstOrNull()?.uppercase() ?: "?",
+                        style = MaterialTheme.typography.headlineLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "탭하여 프로필 관리",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            
+            // Stats Row
+            if (!stats.isNullOrEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    stats.forEach { stat ->
+                        ProfileStatCard(
+                            label = stat.label,
+                            value = stat.value,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+data class ProfileStat(
+    val label: String,
+    val value: String,
+)
+
+@Composable
+private fun ProfileStatCard(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+// ============================================================================
+// SECTION 8: STATUS BADGES
+// Status indicators and badges
+// ============================================================================
+
+/**
+ * Status badge for displaying status.
+ * Use for active/inactive states, labels, etc.
+ */
+@Composable
+fun StatusBadge(
+    text: String,
+    modifier: Modifier = Modifier,
+    isActive: Boolean = false,
+) {
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = if (isActive) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Text(
+            text = text,
+            modifier = modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            style = MaterialTheme.typography.labelMedium,
+            color = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+/** Legacy alias */
+@Composable
+fun GajaStatusBadge(
+    text: String,
+    modifier: Modifier = Modifier,
+    isActive: Boolean = false,
+) = StatusBadge(text, modifier, isActive)
+
+// ============================================================================
+// SECTION 9: LEGACY HEADERS
+// Backward compatibility for existing screens
+// ============================================================================
+
+@Composable
+fun GajaHeader(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                Brush.horizontalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.tertiary,
+                    ),
+                ),
+            )
+            .padding(horizontal = 24.dp, vertical = 28.dp),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.92f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun GajaCompactHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.primary)
+            .padding(horizontal = 24.dp, vertical = 20.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimary,
+        )
+    }
+}
+
+@Composable
+fun GajaBrandTopBar(
+    title: String,
+    subtitle: String? = null,
+    showSettings: Boolean = false,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                ) {
+                    Text(
+                        text = "GAJA RIDE",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                if (showSettings) {
+                    IconButton(onClick = {}) {
+                        androidx.compose.material3.Icon(Icons.Filled.Settings, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    }
+                }
+                IconButton(onClick = {}) {
+                    androidx.compose.material3.Icon(Icons.Filled.Notifications, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursePreRideScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursePreRideScreen.kt
@@ -2,20 +2,32 @@ package com.bikeprojectminji.bikefront.ui.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 fun CoursePreRideScreen(
@@ -24,56 +36,128 @@ fun CoursePreRideScreen(
     onBack: () -> Unit,
     onStartRide: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .background(MaterialTheme.colorScheme.background),
+    val context = LocalContext.current
+    val repository = remember(context) { CoursesRepository(context) }
+    val detailResult by produceState<Result<CourseCardUiModel>?>(initialValue = null, key1 = course.id) {
+        value = runCatching {
+            withContext(Dispatchers.IO) { repository.fetchCourseDetail(course.id) }
+        }
+    }
+    val resolvedCourse = detailResult?.getOrNull() ?: course
+    val detailLoading = detailResult == null
+    val detailError = detailResult?.exceptionOrNull() != null
+
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            GajaBrandTopBar(
+                title = "코스 따라가기",
+                subtitle = "코스 개요를 확인하고 바로 주행을 시작합니다",
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f),
+                                MaterialTheme.colorScheme.background,
+                            ),
+                        ),
+                    )
+                    .padding(
+                        horizontal = GajaSpacing.ScreenPadding,
+                        vertical = GajaSpacing.Large,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(GajaSpacing.Large),
+            ) {
+                CourseLaunchHero(course = resolvedCourse)
+
+                BikeSurfaceCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(GajaSpacing.CardPadding),
+                        verticalArrangement = Arrangement.spacedBy(GajaSpacing.Small),
+                    ) {
+                        SectionHeader(title = "주행 개요")
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            MetricChip(label = "거리", value = formatDistance(resolvedCourse.distanceKm), modifier = Modifier.weight(1f))
+                            MetricChip(label = "예상시간", value = "${resolvedCourse.estimatedDurationMin}분", modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+
+                if (detailLoading) {
+                    LoadingStateView(message = "코스 정보를 확인하는 중입니다.")
+                } else if (detailError) {
+                    ErrorStateView(
+                        title = "시작할 수 없습니다",
+                        message = "코스 정보를 불러오지 못했습니다. 다시 시도해 주세요.",
+                    )
+                }
+
+                PrimaryActionButton(
+                    text = "이 코스로 라이딩 시작",
+                    enabled = !detailLoading && !detailError,
+                    onClick = onStartRide,
+                )
+
+                SecondaryActionButton(
+                    text = "코스 탐색으로 돌아가기",
+                    onClick = onBack,
+                )
+                Spacer(modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding()))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CourseLaunchHero(course: CourseCardUiModel) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.inverseSurface,
     ) {
-        // GAJA Header
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.primary)
-                .padding(horizontal = 24.dp, vertical = 20.dp),
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.inverseSurface,
+                            MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.94f),
+                        ),
+                    ),
+                )
+                .padding(GajaSpacing.CardPadding),
+            verticalArrangement = Arrangement.spacedBy(GajaSpacing.Medium),
         ) {
+            StatusBadge(text = if (course.isRecorded) "기록 코스" else "추천 코스", isActive = true)
             Text(
-                text = "코스 따라가기",
+                text = course.title,
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimary,
+                color = MaterialTheme.colorScheme.inverseOnSurface,
             )
+            Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small)) {
+                MetricChip(label = "거리", value = formatDistance(course.distanceKm), modifier = Modifier.weight(1f))
+                MetricChip(label = "예상시간", value = "${course.estimatedDurationMin}분", modifier = Modifier.weight(1f))
+            }
         }
+    }
+}
 
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-        ) {
-            // Course Info Section
-            SectionTitle(
-                title = "선택한 코스",
-                subtitle = "코스 정보를 확인하고 라이딩을 시작하세요.",
-            )
-
-            // Course Card
-            CourseCard(course = course)
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            // Action Buttons
-            GajaPrimaryCard(
-                title = "라이딩 시작",
-                description = "이 코스를 따라 라이딩을 시작합니다.",
-                buttonText = "이 코스로 시작",
-                onClick = onStartRide,
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            GajaOutlinedButton(
-                text = "뒤로 가기",
-                onClick = onBack,
-            )
-        }
+private fun formatDistance(distanceKm: Double): String {
+    return if (distanceKm < 1.0) {
+        "${(distanceKm * 1000).toInt()}m"
+    } else {
+        "%.1fkm".format(distanceKm)
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesScreen.kt
@@ -1,22 +1,46 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -24,20 +48,39 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MyLocation
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private enum class CourseTab(val label: String) {
-    RECOMMENDED("추천"),
-    ALL("전체"),
+// === Course Tab State ===
+private enum class CourseTab(val label: String, val description: String) {
+    RECOMMENDED("추천", "엄선된 인기 코스"),
+    ALL("전체", "모든 코스 둘러보기"),
 }
 
+// === Loading State ===
+private sealed class CoursesLoadState {
+    data object Loading : CoursesLoadState()
+    data class Success(val courses: List<CourseCardUiModel>) : CoursesLoadState()
+    data class Error(val message: String) : CoursesLoadState()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CoursesScreen(
     innerPadding: PaddingValues,
@@ -48,6 +91,7 @@ fun CoursesScreen(
     val repository = remember(context) { CoursesRepository(context) }
     var selectedTab by remember { mutableStateOf(CourseTab.RECOMMENDED) }
     var refreshKey by remember { mutableStateOf(0) }
+    var isRefreshing by remember { mutableStateOf(false) }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -61,98 +105,519 @@ fun CoursesScreen(
         }
     }
 
-    val featuredState = produceState<List<CourseCardUiModel>>(initialValue = emptyList(), key1 = refreshKey) {
-        value = runCatching { withContext(Dispatchers.IO) { repository.fetchFeaturedCourses() } }.getOrDefault(emptyList())
-    }
-    val allCoursesState = produceState<CoursesPageUiModel?>(initialValue = null, key1 = refreshKey) {
-        value = runCatching { withContext(Dispatchers.IO) { repository.fetchAllCourses() } }.getOrNull()
+    val featuredState = produceState<CoursesLoadState>(initialValue = CoursesLoadState.Loading, key1 = refreshKey) {
+        value = CoursesLoadState.Loading
+        value = runCatching {
+            val courses = withContext(Dispatchers.IO) { repository.fetchFeaturedCourses() }
+            CoursesLoadState.Success(courses)
+        }.getOrElse { CoursesLoadState.Error(it.message ?: "코스를 불러오지 못했습니다") }
     }
 
-    Column(
+    val allCoursesState = produceState<CoursesLoadState>(initialValue = CoursesLoadState.Loading, key1 = refreshKey) {
+        value = CoursesLoadState.Loading
+        value = runCatching {
+            val page = withContext(Dispatchers.IO) { repository.fetchAllCourses() }
+            CoursesLoadState.Success(page?.items.orEmpty())
+        }.getOrElse { CoursesLoadState.Error(it.message ?: "코스를 불러오지 못했습니다") }
+    }
+
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    val pullToRefreshState = rememberPullToRefreshState()
+
+    Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .padding(innerPadding)
-            .background(MaterialTheme.colorScheme.background),
-    ) {
-        // GAJA Header
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.primary)
-                .padding(horizontal = 24.dp, vertical = 20.dp),
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {},
+    ) { scaffoldPadding ->
+        PullToRefreshBox(
+            state = pullToRefreshState,
+            isRefreshing = isRefreshing,
+            onRefresh = {
+                isRefreshing = true
+                refreshKey++
+                isRefreshing = false
+            },
         ) {
-            Text(
-                text = "코스",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-
-        Column(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-        ) {
-            // Tab Chips
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                CourseTab.entries.forEach { tab ->
-                    FilterChip(
-                        selected = selectedTab == tab,
-                        onClick = { selectedTab = tab },
-                        label = {
-                            Text(
-                                text = tab.label,
-                                fontWeight = if (selectedTab == tab) FontWeight.SemiBold else FontWeight.Normal,
-                            )
-                        },
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = MaterialTheme.colorScheme.primary,
-                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(scaffoldPadding)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.15f),
+                                MaterialTheme.colorScheme.background,
+                            ),
                         ),
-                        shape = RoundedCornerShape(12.dp),
+                    ),
+            ) {
+                GajaBrandTopBar(title = "전체 코스", subtitle = "추천 코스와 전체 코스를 탐색하세요")
+
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text("코스 탐색", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+                        Text("거리, 시간, 저장 여부를 빠르게 비교하고 바로 출발할 수 있게 정리했습니다.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    // === Tab Selector with Visual Hierarchy ===
+                    CourseTabSelector(
+                        selectedTab = selectedTab,
+                        onTabSelected = { selectedTab = it },
                     )
-                }
-            }
 
-            // Course List
-            val courses = if (selectedTab == CourseTab.RECOMMENDED) featuredState.value else allCoursesState.value?.items.orEmpty()
+                    // === Content based on selected tab ===
+                    val loadState = if (selectedTab == CourseTab.RECOMMENDED) featuredState.value else allCoursesState.value
 
-            if (courses.isEmpty()) {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(32.dp),
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = fadeIn(animationSpec = tween(300)) + slideInVertically(),
+                        exit = fadeOut(animationSpec = tween(300)) + slideOutVertically(),
                     ) {
-                        Text(
-                            text = if (selectedTab == CourseTab.RECOMMENDED) "추천 코스를 준비 중입니다." else "전체 코스를 준비 중입니다.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            } else {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    items(courses, key = { it.id }) { course ->
-                        CourseCard(course = course, onClick = { onOpenCourse(course) })
-                    }
-                    if (selectedTab == CourseTab.ALL && allCoursesState.value?.hasNext == true) {
-                        item {
-                            GajaSecondaryButton(
-                                text = "추가 코스 불러오기는 아직 연결하지 않았습니다",
-                                onClick = { },
-                                enabled = false,
-                            )
+                        when (loadState) {
+                            is CoursesLoadState.Loading -> {
+                                CourseLoadingState()
+                            }
+                            is CoursesLoadState.Error -> {
+                                CourseErrorState(
+                                    message = loadState.message,
+                                    onRetry = { refreshKey++ },
+                                )
+                            }
+                            is CoursesLoadState.Success -> {
+                                if (loadState.courses.isEmpty()) {
+                                    CourseEmptyState(tab = selectedTab)
+                                } else {
+                                    CourseListContent(
+                                        courses = loadState.courses,
+                                        selectedTab = selectedTab,
+                                        onOpenCourse = onOpenCourse,
+                                    )
+                                }
+                            }
                         }
                     }
                 }
             }
+        }
+    }
+}
+
+// === Tab Selector Component ===
+@Composable
+private fun CourseTabSelector(
+    selectedTab: CourseTab,
+    onTabSelected: (CourseTab) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CourseTab.entries.forEach { tab ->
+            val isSelected = selectedTab == tab
+            val elevation by animateDpAsState(
+                targetValue = if (isSelected) 4.dp else 1.dp,
+                animationSpec = tween(200),
+                label = "elevation",
+            )
+
+            ElevatedCard(
+                modifier = Modifier.weight(1f),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface,
+                ),
+                elevation = CardDefaults.elevatedCardElevation(defaultElevation = elevation),
+                onClick = { onTabSelected(tab) },
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = tab.label,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = tab.description,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f) else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// === Loading State Component ===
+@Composable
+private fun CourseLoadingState() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(300.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                strokeWidth = 3.dp,
+            )
+            Text(
+                text = "코스를 불러오는 중...",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// === Error State Component ===
+@Composable
+private fun CourseErrorState(
+    message: String,
+    onRetry: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "코스를 불러오지 못했습니다",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f),
+            )
+            GajaSecondaryButton(
+                text = "다시 시도",
+                onClick = onRetry,
+            )
+        }
+    }
+}
+
+// === Empty State Component ===
+@Composable
+private fun CourseEmptyState(tab: CourseTab) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = if (tab == CourseTab.RECOMMENDED) "추천 코스를 준비 중입니다" else "전체 코스를 준비 중입니다",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = "잠시 후 다시 확인해주세요",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// === Course List Content ===
+@Composable
+private fun CourseListContent(
+    courses: List<CourseCardUiModel>,
+    selectedTab: CourseTab,
+    onOpenCourse: (CourseCardUiModel) -> Unit,
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // === Featured Course (first item highlighted) ===
+        if (selectedTab == CourseTab.RECOMMENDED && courses.isNotEmpty()) {
+            item {
+                FeaturedCourseCard(
+                    course = courses.first(),
+                    onClick = { onOpenCourse(courses.first()) },
+                )
+            }
+        }
+
+        // === Remaining courses ===
+        items(
+            items = if (selectedTab == CourseTab.RECOMMENDED) courses.drop(1) else courses,
+            key = { it.id },
+        ) { course ->
+            EnhancedCourseCard(
+                course = course,
+                onClick = { onOpenCourse(course) },
+            )
+        }
+
+        // === Continue Recent Course Card ===
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            ContinueCourseCard()
+        }
+    }
+}
+
+// === Featured Course Card (Hero treatment) ===
+@Composable
+private fun FeaturedCourseCard(
+    course: CourseCardUiModel,
+    onClick: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp),
+        onClick = onClick,
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            // === Badge Row ===
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                ) {
+                    Text(
+                        text = "추천 루트",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+                if (course.isRecorded) {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.tertiary,
+                    ) {
+                        Text(
+                            text = "기록",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onTertiary,
+                        )
+                    }
+                }
+            }
+
+            // === Title ===
+            Text(
+                text = course.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            // === Metrics Grid ===
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                FeaturedMetricChip(
+                    icon = Icons.Outlined.MyLocation,
+                    label = "거리",
+                    value = "%.1f km".format(course.distanceKm),
+                )
+                FeaturedMetricChip(
+                    icon = Icons.Outlined.Schedule,
+                    label = "예상",
+                    value = "${course.estimatedDurationMin}분",
+                )
+            }
+        }
+    }
+}
+
+// === Featured Metric Chip ===
+@Composable
+private fun FeaturedMetricChip(
+    icon: ImageVector,
+    label: String,
+    value: String,
+) {
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+// === Enhanced Course Card ===
+@Composable
+private fun EnhancedCourseCard(
+    course: CourseCardUiModel,
+    onClick: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+        onClick = onClick,
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            // === Title Row ===
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = course.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (course.isRecorded) {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Text(
+                            text = "기록",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
+            }
+
+            // === Metrics Row ===
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                MetricChip(
+                    label = "거리",
+                    value = "%.1f km".format(course.distanceKm),
+                    icon = "·",
+                )
+                MetricChip(
+                    label = "예상",
+                    value = "${course.estimatedDurationMin}분",
+                    icon = "·",
+                )
+            }
+        }
+    }
+}
+
+// === Continue Course Card ===
+@Composable
+private fun ContinueCourseCard() {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(22.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(22.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = "최근 코스 이어가기",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Text(
+                        text = "마지막으로 본 코스에서 바로 시작",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.85f),
+                    )
+                }
+            }
+            Text(
+                text = "다음 단계에서 최근 코스 기능을 연결합니다",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/FreeRidePreRideScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/FreeRidePreRideScreen.kt
@@ -2,33 +2,26 @@ package com.bikeprojectminji.bikefront.ui.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 
 @Composable
 fun FreeRidePreRideScreen(
@@ -36,135 +29,99 @@ fun FreeRidePreRideScreen(
     onBack: () -> Unit,
     onStartRide: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .background(MaterialTheme.colorScheme.background),
-    ) {
-        // GAJA Header
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.primary)
-                .padding(horizontal = 24.dp, vertical = 20.dp),
-        ) {
-            Text(
-                text = "자유 주행 준비",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { scaffoldPadding ->
         Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPadding)
+                .verticalScroll(rememberScrollState()),
         ) {
-            // Info Card
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .shadow(
-                        elevation = 4.dp,
-                        shape = RoundedCornerShape(16.dp),
-                        spotColor = Color(0x15000000),
-                    ),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
-                shape = RoundedCornerShape(16.dp),
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        text = "자유 주행 모드",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onBackground,
-                    )
-                    Text(
-                        text = "코스 없이 바로 기록하는 모드입니다. 지도/포인터/저장 흐름은 다음 구현 단계에서 연결합니다.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
-            // Feature List
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .shadow(
-                        elevation = 2.dp,
-                        shape = RoundedCornerShape(16.dp),
-                        spotColor = Color(0x10000000),
-                    ),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                ),
-                shape = RoundedCornerShape(16.dp),
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    FeatureRow(
-                        icon = Icons.Default.LocationOn,
-                        text = "courseId 없이 시작합니다",
-                    )
-                    FeatureRow(
-                        icon = Icons.Default.CheckCircle,
-                        text = "현재 위치 포인터가 우선이어야 합니다",
-                    )
-                    FeatureRow(
-                        icon = Icons.Default.Save,
-                        text = "종료 후 기록 코스를 전체 코스에 반영하는 흐름으로 이어집니다",
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            // Action Buttons
-            GajaPrimaryCard(
-                title = "시작 준비",
-                description = "자유 주행을 시작하려면 아래 버튼을 눌러주세요.",
-                buttonText = "자유 주행 시작",
-                onClick = onStartRide,
+            GajaBrandTopBar(
+                title = "자유 주행",
+                subtitle = "출발 전 상태를 보고 바로 기록을 시작합니다",
             )
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f),
+                                MaterialTheme.colorScheme.background,
+                            ),
+                        ),
+                    )
+                    .padding(
+                        horizontal = GajaSpacing.ScreenPadding,
+                        vertical = GajaSpacing.Large,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(GajaSpacing.Large),
+            ) {
+                FreeRideHero()
 
-            GajaOutlinedButton(
-                text = "뒤로 가기",
-                onClick = onBack,
-            )
+                BikeSurfaceCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(GajaSpacing.CardPadding),
+                        verticalArrangement = Arrangement.spacedBy(GajaSpacing.Small),
+                    ) {
+                        SectionHeader(title = "자유 주행 정보")
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            MetricChip(label = "시작점", value = "현재 위치", modifier = Modifier.weight(1f))
+                            MetricChip(label = "기록 방식", value = "독립 기록", modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+
+                PrimaryActionButton(
+                    text = "자유 주행 시작",
+                    onClick = onStartRide,
+                )
+
+                SecondaryActionButton(
+                    text = "뒤로 가기",
+                    onClick = onBack,
+                )
+                Spacer(modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding()))
+            }
         }
     }
 }
 
 @Composable
-private fun FeatureRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    text: String,
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
+private fun FreeRideHero() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.inverseSurface,
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(top = 2.dp),
-        )
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.inverseSurface,
+                            MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.94f),
+                        ),
+                    ),
+                )
+                .padding(GajaSpacing.CardPadding),
+            verticalArrangement = Arrangement.spacedBy(GajaSpacing.Medium),
+        ) {
+            StatusBadge(text = "GPS 신호 양호", isActive = true)
+            Text(
+                text = "자유 주행을 바로 시작할 수 있습니다",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.inverseOnSurface,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Small)) {
+                MetricChip(label = "위치 상태", value = "안정적", modifier = Modifier.weight(1f))
+                MetricChip(label = "기록 준비", value = "즉시 가능", modifier = Modifier.weight(1f))
+            }
+        }
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -53,6 +54,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bikeprojectminji.bikefront.auth.AuthSessionStore
+import com.bikeprojectminji.bikefront.ui.theme.GajaIconTokens
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -260,10 +262,10 @@ private fun NotLoggedInContent(onOpenProfile: () -> Unit) {
 
         GajaFeatureCard(
             features = listOf(
-                FeatureItem(icon = "•", text = "주행 경로 저장 및 공유"),
-                FeatureItem(icon = "•", text = "상세 주행 통계 분석"),
-                FeatureItem(icon = "•", text = "나만의 코스 만들기"),
-                FeatureItem(icon = "•", text = "라이딩 이력 관리"),
+                FeatureItem(icon = "", text = "주행 경로 저장 및 공유"),
+                FeatureItem(icon = "", text = "상세 주행 통계 분석"),
+                FeatureItem(icon = "", text = "나만의 코스 만들기"),
+                FeatureItem(icon = "", text = "라이딩 이력 관리"),
             ),
         )
     }
@@ -410,19 +412,16 @@ private fun EnhancedProfileHeroCard(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 QuickStatItem(
-                    icon = "📍",
                     label = "누적",
                     value = "1,248 km",
                     modifier = Modifier.weight(1f),
                 )
                 QuickStatItem(
-                    icon = "🏔",
                     label = "고도",
                     value = "8,520 m",
                     modifier = Modifier.weight(1f),
                 )
                 QuickStatItem(
-                    icon = "🚴",
                     label = "주행",
                     value = "42회",
                     modifier = Modifier.weight(1f),
@@ -435,7 +434,6 @@ private fun EnhancedProfileHeroCard(
 // === Quick Stat Item ===
 @Composable
 private fun QuickStatItem(
-    icon: String,
     label: String,
     value: String,
     modifier: Modifier = Modifier,
@@ -450,10 +448,6 @@ private fun QuickStatItem(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Text(
-                text = icon,
-                style = MaterialTheme.typography.titleLarge,
-            )
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,
@@ -483,14 +477,12 @@ private fun StatsGridSection(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             StatMetricCard(
-                icon = "📍",
                 title = "총 거리",
                 value = totalDistance,
                 subtitle = "누적 주행",
                 modifier = Modifier.weight(1f),
             )
             StatMetricCard(
-                icon = "🏔",
                 title = "획득 고도",
                 value = totalElevation,
                 subtitle = "총 상승",
@@ -502,14 +494,12 @@ private fun StatsGridSection(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             StatMetricCard(
-                icon = "🚴",
                 title = "주행 횟수",
                 value = totalRides,
                 subtitle = "완료한 라이딩",
                 modifier = Modifier.weight(1f),
             )
             StatMetricCard(
-                icon = "⚡",
                 title = "평균 속도",
                 value = avgSpeed,
                 subtitle = "전체 평균",
@@ -522,7 +512,6 @@ private fun StatsGridSection(
 // === Stat Metric Card ===
 @Composable
 private fun StatMetricCard(
-    icon: String,
     title: String,
     value: String,
     subtitle: String,
@@ -541,10 +530,6 @@ private fun StatMetricCard(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text(
-                text = icon,
-                style = MaterialTheme.typography.headlineSmall,
-            )
             Text(
                 text = title,
                 style = MaterialTheme.typography.labelMedium,
@@ -569,112 +554,58 @@ private fun StatMetricCard(
 @Composable
 private fun QuickActionsSection(onOpenProfile: () -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        // === Recorded Courses ===
-        ElevatedCard(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(20.dp),
-            colors = CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
-            ),
-            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(20.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Surface(
-                    shape = RoundedCornerShape(14.dp),
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                ) {
-                    Box(
-                        modifier = Modifier.size(48.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "🗺",
-                            style = MaterialTheme.typography.headlineSmall,
-                        )
-                    }
-                }
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        text = "기록한 코스",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                    Text(
-                        text = "저장한 코스를 확인하고 관리합니다",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Text(
-                    text = "→",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-        }
+        ActivityRow(
+            icon = GajaIconTokens.Saved,
+            title = "기록한 코스",
+            description = "저장한 코스를 확인하고 관리합니다",
+        )
+        ActivityRow(
+            icon = GajaIconTokens.Stats,
+            title = "내 기록",
+            description = "상세 주행 통계를 확인합니다",
+        )
+    }
+}
 
-        // === My Records ===
-        ElevatedCard(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(20.dp),
-            colors = CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
-            ),
-            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+@Composable
+private fun ActivityRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    description: String,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 1.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(20.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
             ) {
-                Surface(
-                    shape = RoundedCornerShape(14.dp),
-                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                Box(
+                    modifier = Modifier
+                        .size(40.dp),
+                    contentAlignment = Alignment.Center,
                 ) {
-                    Box(
-                        modifier = Modifier.size(48.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "📊",
-                            style = MaterialTheme.typography.headlineSmall,
-                        )
-                    }
+                    Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
                 }
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        text = "내 기록",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                    Text(
-                        text = "상세 주행 통계를 확인합니다",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Text(
-                    text = "→",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                )
             }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+                Text(description, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Icon(GajaIconTokens.Direction, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
         }
     }
 }
@@ -686,14 +617,12 @@ private fun AccountSection(onOpenProfile: () -> Unit) {
         GajaSecondaryButton(
             text = "프로필 관리",
             onClick = onOpenProfile,
-            icon = "⚙️",
         )
 
         GajaOutlinedButton(
             text = "로그아웃",
             onClick = { /* TODO: Implement logout */ },
             enabled = false,
-            icon = "🚪",
         )
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
@@ -1,32 +1,76 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bikeprojectminji.bikefront.auth.AuthSessionStore
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
+// === Profile State ===
+private sealed class ProfileState {
+    data object Loading : ProfileState()
+    data class Loaded(
+        val displayName: String,
+        val totalDistance: String = "1,248 km",
+        val totalElevation: String = "8,520 m",
+        val totalRides: String = "42",
+        val avgSpeed: String = "18.5 km/h",
+    ) : ProfileState()
+    data object NotLoggedIn : ProfileState()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyInfoScreen(
     innerPadding: PaddingValues,
@@ -35,12 +79,19 @@ fun MyInfoScreen(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val authSessionStore = remember(context) { AuthSessionStore(context) }
-    var displayName by remember { mutableStateOf(authSessionStore.displayName?.takeIf { it.isNotBlank() } ?: "아직 로그인하지 않았습니다") }
+    var profileState by remember { mutableStateOf<ProfileState>(ProfileState.Loading) }
+    var isRefreshing by remember { mutableStateOf(false) }
 
     DisposableEffect(lifecycleOwner, authSessionStore) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                displayName = authSessionStore.displayName?.takeIf { it.isNotBlank() } ?: "아직 로그인하지 않았습니다"
+                profileState = ProfileState.Loading
+                val displayName = authSessionStore.displayName?.takeIf { it.isNotBlank() }
+                profileState = if (displayName != null) {
+                    ProfileState.Loaded(displayName = displayName)
+                } else {
+                    ProfileState.NotLoggedIn
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -49,56 +100,600 @@ fun MyInfoScreen(
         }
     }
 
-    Column(
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    val pullToRefreshState = rememberPullToRefreshState()
+
+    Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .padding(innerPadding)
-            .background(MaterialTheme.colorScheme.background),
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {},
+    ) { scaffoldPadding ->
+        PullToRefreshBox(
+            state = pullToRefreshState,
+            isRefreshing = isRefreshing,
+            onRefresh = {
+                isRefreshing = true
+                val displayName = authSessionStore.displayName?.takeIf { it.isNotBlank() }
+                profileState = if (displayName != null) {
+                    ProfileState.Loaded(displayName = displayName)
+                } else {
+                    ProfileState.NotLoggedIn
+                }
+                isRefreshing = false
+            },
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(scaffoldPadding)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.15f),
+                                MaterialTheme.colorScheme.background,
+                            ),
+                        ),
+                    )
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                GajaBrandTopBar(title = "내 정보", subtitle = "주행 기록과 계정을 확인하세요", showSettings = true)
+                AnimatedVisibility(
+                    visible = true,
+                    enter = fadeIn(animationSpec = tween(300)) + slideInVertically(),
+                    exit = fadeOut(animationSpec = tween(300)) + slideOutVertically(),
+                ) {
+                    when (val state = profileState) {
+                        is ProfileState.Loading -> {
+                            ProfileLoadingState()
+                        }
+                        is ProfileState.NotLoggedIn -> {
+                            NotLoggedInContent(onOpenProfile = onOpenProfile)
+                        }
+                        is ProfileState.Loaded -> {
+                            ProfileContent(
+                                displayName = state.displayName,
+                                totalDistance = state.totalDistance,
+                                totalElevation = state.totalElevation,
+                                totalRides = state.totalRides,
+                                avgSpeed = state.avgSpeed,
+                                onOpenProfile = onOpenProfile,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// === Loading State ===
+@Composable
+private fun ProfileLoadingState() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(400.dp),
+        contentAlignment = Alignment.Center,
     ) {
-        // GAJA Header
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.primary)
-                .padding(horizontal = 24.dp, vertical = 20.dp),
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                strokeWidth = 3.dp,
+            )
+            Text(
+                text = "프로필을 불러오는 중...",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// === Not Logged In Content ===
+@Composable
+private fun NotLoggedInContent(onOpenProfile: () -> Unit) {
+    Column(
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(28.dp),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.inverseSurface,
+            ),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.inverseSurface,
+                                MaterialTheme.colorScheme.surfaceContainerHigh,
+                            ),
+                        ),
+                    )
+                    .padding(28.dp),
+                verticalArrangement = Arrangement.spacedBy(18.dp),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.16f),
+                ) {
+                    Text(
+                        text = "게스트 모드",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                Text(
+                    text = "로그인하면 라이딩 기록이 쌓입니다",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                )
+                Text(
+                    text = "주행 기록 저장, 코스 보관, 계정 기반 동기화까지 한 흐름으로 이어집니다. 지금은 둘러보기만 가능하고 데이터는 남지 않습니다.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.84f),
+                )
+                PrimaryActionButton(
+                    text = "로그인 / 회원가입",
+                    onClick = onOpenProfile,
+                )
+            }
+        }
+
+        SectionHeader(
+            title = "로그인 후 이용 가능",
+            subtitle = "계정이 생기면 아래 기능이 실제 자산으로 누적됩니다",
+        )
+
+        GajaFeatureCard(
+            features = listOf(
+                FeatureItem(icon = "•", text = "주행 경로 저장 및 공유"),
+                FeatureItem(icon = "•", text = "상세 주행 통계 분석"),
+                FeatureItem(icon = "•", text = "나만의 코스 만들기"),
+                FeatureItem(icon = "•", text = "라이딩 이력 관리"),
+            ),
+        )
+    }
+}
+
+// === Profile Content (Logged In) ===
+@Composable
+private fun ProfileContent(
+    displayName: String,
+    totalDistance: String,
+    totalElevation: String,
+    totalRides: String,
+    avgSpeed: String,
+    onOpenProfile: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        // === Profile Hero Card ===
+        EnhancedProfileHeroCard(
+            displayName = displayName,
+            onProfileClick = onOpenProfile,
+        )
+
+        // === Stats Grid ===
+        StatsGridSection(
+            totalDistance = totalDistance,
+            totalElevation = totalElevation,
+            totalRides = totalRides,
+            avgSpeed = avgSpeed,
+        )
+
+        // === Quick Actions ===
+        SectionHeader(
+            title = "활동",
+            subtitle = "주행 기록과 저장한 코스를 관리하세요",
+        )
+
+        QuickActionsSection(onOpenProfile = onOpenProfile)
+
+        // === Account Section ===
+        SectionHeader(
+            title = "계정",
+            subtitle = "프로필 및 설정을 관리합니다",
+        )
+
+        AccountSection(onOpenProfile = onOpenProfile)
+    }
+}
+
+// === Enhanced Profile Hero Card ===
+@Composable
+private fun EnhancedProfileHeroCard(
+    displayName: String,
+    onProfileClick: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.inverseSurface,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 3.dp),
+        onClick = onProfileClick,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            // === Gradient Header ===
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.horizontalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.inverseSurface,
+                                MaterialTheme.colorScheme.surfaceContainerHigh,
+                            ),
+                        ),
+                    )
+                    .padding(24.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(18.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // === Avatar ===
+                    Box(
+                        modifier = Modifier
+                            .size(72.dp)
+                            .clip(CircleShape)
+                            .background(
+                                Brush.linearGradient(
+                                    colors = listOf(
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.45f),
+                                        MaterialTheme.colorScheme.tertiary.copy(alpha = 0.25f),
+                                    ),
+                                ),
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = displayName.firstOrNull()?.uppercase() ?: "?",
+                            style = MaterialTheme.typography.headlineLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.inverseOnSurface,
+                        )
+                    }
+
+                    // === Name and Status ===
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Text(
+                            text = displayName,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.inverseOnSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Surface(
+                            shape = RoundedCornerShape(12.dp),
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.18f),
+                        ) {
+                            Text(
+                                text = "탭하여 프로필 관리",
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+            }
+
+            // === Quick Stats Row ===
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                QuickStatItem(
+                    icon = "📍",
+                    label = "누적",
+                    value = "1,248 km",
+                    modifier = Modifier.weight(1f),
+                )
+                QuickStatItem(
+                    icon = "🏔",
+                    label = "고도",
+                    value = "8,520 m",
+                    modifier = Modifier.weight(1f),
+                )
+                QuickStatItem(
+                    icon = "🚴",
+                    label = "주행",
+                    value = "42회",
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+// === Quick Stat Item ===
+@Composable
+private fun QuickStatItem(
+    icon: String,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.85f),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Text(
-                text = "내 정보",
+                text = icon,
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+// === Stats Grid Section ===
+@Composable
+private fun StatsGridSection(
+    totalDistance: String,
+    totalElevation: String,
+    totalRides: String,
+    avgSpeed: String,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            StatMetricCard(
+                icon = "📍",
+                title = "총 거리",
+                value = totalDistance,
+                subtitle = "누적 주행",
+                modifier = Modifier.weight(1f),
+            )
+            StatMetricCard(
+                icon = "🏔",
+                title = "획득 고도",
+                value = totalElevation,
+                subtitle = "총 상승",
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            StatMetricCard(
+                icon = "🚴",
+                title = "주행 횟수",
+                value = totalRides,
+                subtitle = "완료한 라이딩",
+                modifier = Modifier.weight(1f),
+            )
+            StatMetricCard(
+                icon = "⚡",
+                title = "평균 속도",
+                value = avgSpeed,
+                subtitle = "전체 평균",
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+// === Stat Metric Card ===
+@Composable
+private fun StatMetricCard(
+    icon: String,
+    title: String,
+    value: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(
+        modifier = modifier,
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = icon,
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimary,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
             )
         }
+    }
+}
 
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
+// === Quick Actions Section ===
+@Composable
+private fun QuickActionsSection(onOpenProfile: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // === Recorded Courses ===
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
         ) {
-            // Profile Card
-            ProfileCard(
-                displayName = displayName,
-                onProfileClick = onOpenProfile,
-            )
-
-            // Info Section
-            SectionTitle(
-                title = "계정",
-                subtitle = "로그인 상태와 추후 기록/설정 진입 영역입니다.",
-            )
-
-            // Action Buttons
-            GajaSecondaryButton(
-                text = "로그인 / 프로필 열기",
-                onClick = onOpenProfile,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            GajaOutlinedButton(
-                text = "내 기록 화면은 아직 연결하지 않았습니다",
-                onClick = { },
-                enabled = false,
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(14.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                ) {
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "🗺",
+                            style = MaterialTheme.typography.headlineSmall,
+                        )
+                    }
+                }
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "기록한 코스",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "저장한 코스를 확인하고 관리합니다",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = "→",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
+
+        // === My Records ===
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(14.dp),
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                ) {
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "📊",
+                            style = MaterialTheme.typography.headlineSmall,
+                        )
+                    }
+                }
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "내 기록",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "상세 주행 통계를 확인합니다",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = "→",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+// === Account Section ===
+@Composable
+private fun AccountSection(onOpenProfile: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        GajaSecondaryButton(
+            text = "프로필 관리",
+            onClick = onOpenProfile,
+            icon = "⚙️",
+        )
+
+        GajaOutlinedButton(
+            text = "로그아웃",
+            onClick = { /* TODO: Implement logout */ },
+            enabled = false,
+            icon = "🚪",
+        )
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
@@ -1,54 +1,51 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
 fun RideStartScreen(
     innerPadding: PaddingValues,
-    onOpenFreeRide: () -> Unit,
+    onStartFreeRide: () -> Unit,
     onOpenCourse: (CourseCardUiModel) -> Unit,
-    onOpenCourses: () -> Unit,
-    onOpenProfile: () -> Unit,
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val repository = remember(context) { CoursesRepository(context) }
+    val coroutineScope = rememberCoroutineScope()
     var refreshKey by remember { mutableStateOf(0) }
+    var featuredState by remember { mutableStateOf<SectionState<List<CourseCardUiModel>>>(SectionState.Loading) }
+    var listState by remember { mutableStateOf<SectionState<CoursesPageUiModel>>(SectionState.Loading) }
+    var loadingMore by remember { mutableStateOf(false) }
+    var loadMoreError by remember { mutableStateOf<String?>(null) }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -57,111 +54,234 @@ fun RideStartScreen(
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    val featuredCourses = produceState<List<CourseCardUiModel>>(initialValue = emptyList(), key1 = refreshKey) {
-        value = runCatching {
-            withContext(Dispatchers.IO) { repository.fetchFeaturedCourses() }
-        }.getOrDefault(emptyList())
-    }
+    LaunchedEffect(refreshKey) {
+        featuredState = SectionState.Loading
+        listState = SectionState.Loading
+        loadingMore = false
+        loadMoreError = null
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(rememberScrollState()),
-    ) {
-        // GAJA Hero Header Section
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    Brush.verticalGradient(
-                        colors = listOf(
-                            MaterialTheme.colorScheme.primary,
-                            MaterialTheme.colorScheme.tertiary,
-                        ),
-                    ),
-                )
-                .padding(horizontal = 24.dp, vertical = 32.dp),
-        ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = "GAJA",
-                    style = MaterialTheme.typography.headlineLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                )
-                Text(
-                    text = "오늘도 안전하게 라이딩하세요",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
-                )
+        launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) { repository.fetchFeaturedCourses() }
             }
+            featuredState = result.fold(
+                onSuccess = { SectionState.Success(it) },
+                onFailure = { SectionState.Error("추천 코스를 불러오지 못했습니다.") },
+            )
         }
 
+        launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) { repository.fetchAllCourses(limit = 10) }
+            }
+            listState = result.fold(
+                onSuccess = { SectionState.Success(it) },
+                onFailure = { SectionState.Error("전체 코스를 불러오지 못했습니다.") },
+            )
+        }
+    }
+
+    val featuredError = featuredState is SectionState.Error
+    val listError = listState is SectionState.Error
+
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { scaffoldPadding ->
         Column(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPadding)
+                .verticalScroll(rememberScrollState()),
         ) {
-            // Free Ride Primary Card
-            GajaPrimaryCard(
-                title = "자유 주행",
-                description = "코스 없이 바로 기록을 시작하는 모드입니다. 현재 위치에서 바로 시작하세요.",
-                buttonText = "자유 주행 시작",
-                onClick = onOpenFreeRide,
-            )
+            GajaBrandTopBar(title = "홈")
 
-            // Recommended Courses Section
-            SectionTitle(
-                title = "추천 코스",
-                subtitle = "빠르게 바로 탈 수 있는 코스를 먼저 보여줍니다.",
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = GajaSpacing.ScreenPadding,
+                        vertical = GajaSpacing.Large,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(GajaSpacing.ScreenPadding),
+            ) {
+                if (featuredError && listError) {
+                    ErrorStateView(
+                        title = "코스 정보를 불러오지 못했습니다",
+                        message = "잠시 후 다시 시도해 주세요.",
+                        onRetry = { refreshKey++ },
+                    )
+                } else {
+                    HeroCard(
+                        title = "바로 출발",
+                        description = "코스 없이도 지금 위치에서 즉시 라이딩을 시작할 수 있습니다.",
+                        buttonText = "자유 주행 열기",
+                        onClick = onStartFreeRide,
+                    )
 
-            if (featuredCourses.value.isEmpty()) {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(32.dp),
-                    ) {
-                        Text(
-                            text = "추천 코스를 불러오는 중이거나 아직 준비되지 않았습니다.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    SectionHeader(
+                        title = "추천 코스",
+                        subtitle = "빠르게 ride 흐름으로 들어갈 수 있는 코스",
+                    )
+                    when (val currentFeaturedState = featuredState) {
+                        SectionState.Loading -> LoadingStateView(message = "추천 코스를 불러오는 중입니다.")
+                        is SectionState.Error -> ErrorStateView(
+                            title = "추천 코스를 불러오지 못했습니다",
+                            message = currentFeaturedState.message,
+                            onRetry = { refreshKey++ },
                         )
+                        is SectionState.Success -> {
+                            val featuredCourses = currentFeaturedState.data
+                            if (featuredCourses.isEmpty()) {
+                                EmptyStateView(
+                                    title = "추천 코스를 준비 중입니다",
+                                    message = "지금은 추천 코스가 없습니다.",
+                                )
+                            } else {
+                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                    FeaturedCourseHeroCard(
+                                        course = featuredCourses.first(),
+                                        onClick = { onOpenCourse(featuredCourses.first()) },
+                                    )
+                                    featuredCourses.drop(1).take(2).forEach { course ->
+                                        CourseCard(course = course, onClick = { onOpenCourse(course) })
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    SectionHeader(
+                        title = "전체 코스 목록",
+                        subtitle = "추천이 부족할 때 직접 탐색하는 영역",
+                    )
+                    when (val currentListState = listState) {
+                        SectionState.Loading -> LoadingStateView(message = "전체 코스를 불러오는 중입니다.")
+                        is SectionState.Error -> ErrorStateView(
+                            title = "전체 코스를 불러오지 못했습니다",
+                            message = currentListState.message,
+                            onRetry = { refreshKey++ },
+                        )
+                        is SectionState.Success -> {
+                            val page = currentListState.data
+                            if (page.items.isEmpty()) {
+                                EmptyStateView(
+                                    title = "전체 코스를 준비 중입니다",
+                                    message = "현재 노출할 코스가 없습니다.",
+                                )
+                            } else {
+                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                    page.items.forEach { course ->
+                                        CourseCard(course = course, onClick = { onOpenCourse(course) })
+                                    }
+                                }
+                            }
+
+                            if (page.hasNext) {
+                                SecondaryActionButton(
+                                    text = if (loadingMore) "불러오는 중..." else "더보기",
+                                    enabled = !loadingMore,
+                                    onClick = {
+                                        val nextCursor = page.nextCursor ?: return@SecondaryActionButton
+                                        coroutineScope.launch {
+                                            loadingMore = true
+                                            loadMoreError = null
+                                            val nextPage = runCatching {
+                                                withContext(Dispatchers.IO) {
+                                                    repository.fetchAllCourses(cursor = nextCursor, limit = 10)
+                                                }
+                                            }
+                                            listState = nextPage.fold(
+                                                onSuccess = {
+                                                    SectionState.Success(
+                                                        page.copy(
+                                                            items = page.items + it.items,
+                                                            hasNext = it.hasNext,
+                                                            nextCursor = it.nextCursor,
+                                                        ),
+                                                    )
+                                                },
+                                                onFailure = {
+                                                    loadMoreError = "추가 코스를 불러오지 못했습니다."
+                                                    currentListState
+                                                },
+                                            )
+                                            loadingMore = false
+                                        }
+                                    },
+                                )
+                            }
+
+                            if (!loadMoreError.isNullOrBlank()) {
+                                BikeSurfaceCard {
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(18.dp),
+                                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                                    ) {
+                                        androidx.compose.material3.Text(
+                                            text = loadMoreError.orEmpty(),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.error,
+                                            fontWeight = FontWeight.SemiBold,
+                                        )
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-            } else {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    featuredCourses.value.forEach { course ->
-                        CourseCard(course = course, onClick = { onOpenCourse(course) })
-                    }
-                }
+
+                androidx.compose.foundation.layout.Spacer(
+                    modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding()),
+                )
             }
-
-            // Secondary Actions
-            GajaSecondaryButton(
-                text = "전체 코스 보러 가기",
-                onClick = onOpenCourses,
-            )
-
-            GajaOutlinedButton(
-                text = "내 정보 / 로그인",
-                onClick = onOpenProfile,
-            )
         }
+    }
+}
+
+private sealed interface SectionState<out T> {
+    data object Loading : SectionState<Nothing>
+    data class Success<T>(val data: T) : SectionState<T>
+    data class Error(val message: String) : SectionState<Nothing>
+}
+
+@Composable
+private fun FeaturedCourseHeroCard(
+    course: CourseCardUiModel,
+    onClick: () -> Unit,
+) {
+    HeroCard(
+        title = course.title,
+        description = "추천 루트로 바로 진입해 라이딩 흐름을 시작합니다.",
+        buttonText = "이 코스 시작",
+        onClick = onClick,
+        gradientColors = listOf(
+            MaterialTheme.colorScheme.inverseSurface,
+            MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        icon = null,
+    )
+
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        MetricChip(
+            label = "거리",
+            value = formatDistance(course.distanceKm),
+            modifier = Modifier.weight(1f),
+        )
+        MetricChip(
+            label = "예상 시간",
+            value = "${course.estimatedDurationMin}분",
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+private fun formatDistance(distanceKm: Double): String {
+    return if (distanceKm < 1.0) {
+        "${(distanceKm * 1000).toInt()}m"
+    } else {
+        "%.1f km".format(distanceKm)
     }
 }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
@@ -114,14 +114,15 @@ fun RideStartScreen(
                 } else {
                     HeroCard(
                         title = "바로 출발",
-                        description = "코스 없이도 지금 위치에서 즉시 라이딩을 시작할 수 있습니다.",
+                        description = "지금 위치에서 바로 기록을 시작하고, 필요할 때 코스로 전환할 수 있습니다.",
                         buttonText = "자유 주행 열기",
                         onClick = onStartFreeRide,
+                        icon = "자유 주행",
                     )
 
                     SectionHeader(
                         title = "추천 코스",
-                        subtitle = "빠르게 ride 흐름으로 들어갈 수 있는 코스",
+                        subtitle = "빠르게 출발하기 좋은 코스",
                     )
                     when (val currentFeaturedState = featuredState) {
                         SectionState.Loading -> LoadingStateView(message = "추천 코스를 불러오는 중입니다.")
@@ -153,7 +154,7 @@ fun RideStartScreen(
 
                     SectionHeader(
                         title = "전체 코스 목록",
-                        subtitle = "추천이 부족할 때 직접 탐색하는 영역",
+                        subtitle = "거리와 시간 중심으로 바로 비교하는 목록",
                     )
                     when (val currentListState = listState) {
                         SectionState.Loading -> LoadingStateView(message = "전체 코스를 불러오는 중입니다.")
@@ -261,7 +262,7 @@ private fun FeaturedCourseHeroCard(
             MaterialTheme.colorScheme.inverseSurface,
             MaterialTheme.colorScheme.secondaryContainer,
         ),
-        icon = null,
+        icon = "추천 코스",
     )
 
     Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/IconTokens.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/IconTokens.kt
@@ -1,0 +1,27 @@
+package com.bikeprojectminji.bikefront.ui.theme
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowForward
+import androidx.compose.material.icons.automirrored.outlined.DirectionsBike
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.Map
+import androidx.compose.material.icons.outlined.MyLocation
+import androidx.compose.material.icons.outlined.PersonOutline
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.outlined.Speed
+import androidx.compose.material.icons.outlined.Straighten
+import androidx.compose.ui.graphics.vector.ImageVector
+
+object GajaIconTokens {
+    val Ride: ImageVector = Icons.AutoMirrored.Outlined.DirectionsBike
+    val Course: ImageVector = Icons.Outlined.Map
+    val Profile: ImageVector = Icons.Outlined.PersonOutline
+    val Distance: ImageVector = Icons.Outlined.Straighten
+    val Duration: ImageVector = Icons.Outlined.Schedule
+    val Saved: ImageVector = Icons.Outlined.BookmarkBorder
+    val Stats: ImageVector = Icons.Outlined.BarChart
+    val Location: ImageVector = Icons.Outlined.MyLocation
+    val Direction: ImageVector = Icons.AutoMirrored.Outlined.ArrowForward
+    val Speed: ImageVector = Icons.Outlined.Speed
+}

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
@@ -29,16 +29,16 @@ import androidx.compose.material3.Typography
 /** Primary brand colors - The core GAJA identity */
 object GajaColors {
     // Primary accents
-    val LimePrimary = Color(0xFFB8FF5A)
-    val LimeLight = Color(0xFFD7FF9E)
-    val LimeDark = Color(0xFF5D7A1F)
-    val LimeSurface = Color(0xFFE9F4D0)
+    val LimePrimary = Color(0xFF7EE2C2)
+    val LimeLight = Color(0xFFB8F2E1)
+    val LimeDark = Color(0xFF24564C)
+    val LimeSurface = Color(0xFFDDF4EC)
 
     // Background & Surfaces
-    val Background = Color(0xFFF3F0E8)
-    val Surface = Color(0xFFFFFCF6)
-    val SurfaceVariant = Color(0xFFE7E0D3)
-    val SurfaceContainer = Color(0xFFF0E8DA)
+    val Background = Color(0xFFF5F3ED)
+    val Surface = Color(0xFFFFFCF8)
+    val SurfaceVariant = Color(0xFFE7E4DB)
+    val SurfaceContainer = Color(0xFFF1ECE3)
 
     // Text
     val TextPrimary = Color(0xFF171611)
@@ -59,14 +59,14 @@ object GajaColors {
 
     // Gradients
     val GradientStart = LimePrimary
-    val GradientEnd = Color(0xFFD57F34)
+    val GradientEnd = Color(0xFF2C5A4F)
 }
 
 /** Light color scheme - Primary theme for GAJA app */
 private val LightColorScheme = lightColorScheme(
     primary = GajaColors.LimePrimary,
     onPrimary = GajaColors.TextPrimary,
-    primaryContainer = Color(0xFFDDEFBF),
+    primaryContainer = Color(0xFFD8F4EB),
     onPrimaryContainer = GajaColors.TextPrimary,
     
     secondary = GajaColors.LimeDark,
@@ -74,9 +74,9 @@ private val LightColorScheme = lightColorScheme(
     secondaryContainer = GajaColors.LimeSurface,
     onSecondaryContainer = GajaColors.TextPrimary,
     
-    tertiary = Color(0xFFE39A45),
+    tertiary = Color(0xFFC69A5F),
     onTertiary = GajaColors.TextPrimary,
-    tertiaryContainer = Color(0xFFF4DBBD),
+    tertiaryContainer = Color(0xFFF1E2CB),
     onTertiaryContainer = GajaColors.TextPrimary,
     
     background = GajaColors.Background,
@@ -89,7 +89,7 @@ private val LightColorScheme = lightColorScheme(
     onSurfaceVariant = GajaColors.TextSecondary,
     
     surfaceContainer = GajaColors.SurfaceContainer,
-    surfaceContainerHigh = Color(0xFFE9DFCF),
+    surfaceContainerHigh = Color(0xFFEDE7DD),
     
     outline = GajaColors.Outline,
     outlineVariant = GajaColors.OutlineVariant,
@@ -108,35 +108,35 @@ private val LightColorScheme = lightColorScheme(
 
 /** Dark color scheme - Dark mode support */
 private val DarkColorScheme = darkColorScheme(
-    primary = Color(0xFF9EF06A),
-    onPrimary = Color(0xFF132012),
-    primaryContainer = Color(0xFF243523),
-    onPrimaryContainer = Color(0xFFE6FFD0),
+    primary = Color(0xFF8BE8CB),
+    onPrimary = Color(0xFF10201C),
+    primaryContainer = Color(0xFF17312B),
+    onPrimaryContainer = Color(0xFFD4F8EE),
 
-    secondary = Color(0xFFACC26F),
-    onSecondary = Color(0xFF1C2114),
-    secondaryContainer = Color(0xFF28311D),
-    onSecondaryContainer = Color(0xFFE4EFCF),
+    secondary = Color(0xFF9CC8B9),
+    onSecondary = Color(0xFF11201B),
+    secondaryContainer = Color(0xFF203631),
+    onSecondaryContainer = Color(0xFFD5ECE5),
 
-    tertiary = Color(0xFFF2B467),
-    onTertiary = Color(0xFF251505),
-    tertiaryContainer = Color(0xFF513012),
-    onTertiaryContainer = Color(0xFFFFD9B6),
+    tertiary = Color(0xFFD5AE78),
+    onTertiary = Color(0xFF23170A),
+    tertiaryContainer = Color(0xFF4E3921),
+    onTertiaryContainer = Color(0xFFF8DFC1),
 
-    background = Color(0xFF0D1815),
+    background = Color(0xFF0C1614),
     onBackground = GajaColors.TextInverse,
 
-    surface = Color(0xFF13211D),
+    surface = Color(0xFF111D1A),
     onSurface = GajaColors.TextInverse,
 
-    surfaceVariant = Color(0xFF1D2B27),
-    onSurfaceVariant = Color(0xFFB9C9C1),
+    surfaceVariant = Color(0xFF1A2A26),
+    onSurfaceVariant = Color(0xFFB7C8C1),
 
-    surfaceContainer = Color(0xFF162520),
-    surfaceContainerHigh = Color(0xFF20332D),
+    surfaceContainer = Color(0xFF152420),
+    surfaceContainerHigh = Color(0xFF1C2F2A),
 
-    outline = Color(0xFF3B4F48),
-    outlineVariant = Color(0xFF22312C),
+    outline = Color(0xFF385049),
+    outlineVariant = Color(0xFF243530),
 
     error = Color(0xFFFF8A72),
     onError = Color(0xFF3B0800),

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
@@ -5,97 +5,399 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 
-// GAJA MVP Color Palette - Mint/Teal with White emphasis
-private val GajaMint = Color(0xFF00BFA5) // Primary mint/teal
-private val GajaMintLight = Color(0xFF64FFDA) // Light mint accent
-private val GajaMintDark = Color(0xFF00897B) // Dark mint for emphasis
+// ============================================================================
+// GAJA Material 3 Design System
+// A premium, cohesive design system built on Material 3 foundations
+// ============================================================================
 
-private val GajaWhite = Color(0xFFFFFFFF) // Pure white
-private val GajaBackground = Color(0xFFF8FAFB) // Soft off-white background
-private val GajaSurface = Color(0xFFFFFFFF) // White surface for cards
-private val GajaSurfaceVariant = Color(0xFFE8F5F3) // Light mint-tinted surface
+// ============================================================================
+// SECTION 1: COLOR TOKENS
+// Brand identity: graphite cockpit with lime and amber accents
+// ============================================================================
 
-private val GajaTextPrimary = Color(0xFF1A1A1A) // Near-black for primary text
-private val GajaTextSecondary = Color(0xFF6B7280) // Gray for secondary text
-private val GajaTextTertiary = Color(0xFF9CA3AF) // Light gray for tertiary
+/** Primary brand colors - The core GAJA identity */
+object GajaColors {
+    // Primary accents
+    val LimePrimary = Color(0xFFB8FF5A)
+    val LimeLight = Color(0xFFD7FF9E)
+    val LimeDark = Color(0xFF5D7A1F)
+    val LimeSurface = Color(0xFFE9F4D0)
 
-private val GajaAccent = Color(0xFF26A69A) // Teal accent
-private val GajaSuccess = Color(0xFF4CAF50) // Green for success states
-private val GajaWarning = Color(0xFFFF9800) // Orange for warnings
-private val GajaError = Color(0xFFE53935) // Red for errors
+    // Background & Surfaces
+    val Background = Color(0xFFF3F0E8)
+    val Surface = Color(0xFFFFFCF6)
+    val SurfaceVariant = Color(0xFFE7E0D3)
+    val SurfaceContainer = Color(0xFFF0E8DA)
 
-private val GajaDivider = Color(0xFFE5E7EB) // Light gray for dividers
-private val GajaCardShadow = Color(0x1A000000) // Subtle shadow
+    // Text
+    val TextPrimary = Color(0xFF171611)
+    val TextSecondary = Color(0xFF5F594D)
+    val TextTertiary = Color(0xFF938C7E)
+    val TextInverse = Color(0xFFFFFFFF)
 
-private val LightColors = lightColorScheme(
-    primary = GajaMint,
-    onPrimary = GajaWhite,
-    primaryContainer = GajaMintLight,
-    onPrimaryContainer = GajaMintDark,
+    // Semantic
+    val Success = Color(0xFF5F8D2D)
+    val Warning = Color(0xFFD7842D)
+    val Error = Color(0xFFB84D37)
+    val Info = Color(0xFF446E8D)
+
+    // UI Elements
+    val Divider = Color(0xFFD8D0C3)
+    val Outline = Color(0xFFC8BEAE)
+    val OutlineVariant = Color(0xFFDED6CA)
+
+    // Gradients
+    val GradientStart = LimePrimary
+    val GradientEnd = Color(0xFFD57F34)
+}
+
+/** Light color scheme - Primary theme for GAJA app */
+private val LightColorScheme = lightColorScheme(
+    primary = GajaColors.LimePrimary,
+    onPrimary = GajaColors.TextPrimary,
+    primaryContainer = Color(0xFFDDEFBF),
+    onPrimaryContainer = GajaColors.TextPrimary,
     
-    secondary = GajaAccent,
-    onSecondary = GajaWhite,
-    secondaryContainer = GajaSurfaceVariant,
-    onSecondaryContainer = GajaTextPrimary,
+    secondary = GajaColors.LimeDark,
+    onSecondary = GajaColors.TextInverse,
+    secondaryContainer = GajaColors.LimeSurface,
+    onSecondaryContainer = GajaColors.TextPrimary,
     
-    tertiary = GajaMintDark,
-    onTertiary = GajaWhite,
+    tertiary = Color(0xFFE39A45),
+    onTertiary = GajaColors.TextPrimary,
+    tertiaryContainer = Color(0xFFF4DBBD),
+    onTertiaryContainer = GajaColors.TextPrimary,
     
-    background = GajaBackground,
-    onBackground = GajaTextPrimary,
+    background = GajaColors.Background,
+    onBackground = GajaColors.TextPrimary,
     
-    surface = GajaSurface,
-    onSurface = GajaTextPrimary,
+    surface = GajaColors.Surface,
+    onSurface = GajaColors.TextPrimary,
     
-    surfaceVariant = GajaSurfaceVariant,
-    onSurfaceVariant = GajaTextSecondary,
+    surfaceVariant = GajaColors.SurfaceVariant,
+    onSurfaceVariant = GajaColors.TextSecondary,
     
-    outline = GajaDivider,
-    outlineVariant = GajaDivider,
+    surfaceContainer = GajaColors.SurfaceContainer,
+    surfaceContainerHigh = Color(0xFFE9DFCF),
     
-    error = GajaError,
-    onError = GajaWhite,
+    outline = GajaColors.Outline,
+    outlineVariant = GajaColors.OutlineVariant,
+    
+    error = GajaColors.Error,
+    onError = GajaColors.TextInverse,
+    errorContainer = Color(0xFFF7DAD4),
+    onErrorContainer = Color(0xFF410E0E),
+    
+    inverseSurface = GajaColors.TextPrimary,
+    inverseOnSurface = GajaColors.Surface,
+    inversePrimary = GajaColors.LimeLight,
+    
+    scrim = Color(0xFF000000),
 )
 
-private val DarkColors = darkColorScheme(
-    primary = GajaMintLight,
-    onPrimary = GajaMintDark,
-    primaryContainer = GajaMintDark,
-    onPrimaryContainer = GajaMintLight,
-    
-    secondary = GajaAccent,
-    onSecondary = GajaWhite,
-    secondaryContainer = Color(0xFF1A3A36),
-    onSecondaryContainer = GajaMintLight,
-    
-    tertiary = GajaMint,
-    onTertiary = GajaMintDark,
-    
-    background = Color(0xFF0D1F1C),
-    onBackground = GajaWhite,
-    
-    surface = Color(0xFF152623),
-    onSurface = GajaWhite,
-    
-    surfaceVariant = Color(0xFF1A3A36),
-    onSurfaceVariant = GajaMintLight,
-    
-    outline = Color(0xFF2D4A45),
-    outlineVariant = Color(0xFF1A3A36),
-    
-    error = Color(0xFFEF5350),
-    onError = Color(0xFF1A0000),
+/** Dark color scheme - Dark mode support */
+private val DarkColorScheme = darkColorScheme(
+    primary = Color(0xFF9EF06A),
+    onPrimary = Color(0xFF132012),
+    primaryContainer = Color(0xFF243523),
+    onPrimaryContainer = Color(0xFFE6FFD0),
+
+    secondary = Color(0xFFACC26F),
+    onSecondary = Color(0xFF1C2114),
+    secondaryContainer = Color(0xFF28311D),
+    onSecondaryContainer = Color(0xFFE4EFCF),
+
+    tertiary = Color(0xFFF2B467),
+    onTertiary = Color(0xFF251505),
+    tertiaryContainer = Color(0xFF513012),
+    onTertiaryContainer = Color(0xFFFFD9B6),
+
+    background = Color(0xFF0D1815),
+    onBackground = GajaColors.TextInverse,
+
+    surface = Color(0xFF13211D),
+    onSurface = GajaColors.TextInverse,
+
+    surfaceVariant = Color(0xFF1D2B27),
+    onSurfaceVariant = Color(0xFFB9C9C1),
+
+    surfaceContainer = Color(0xFF162520),
+    surfaceContainerHigh = Color(0xFF20332D),
+
+    outline = Color(0xFF3B4F48),
+    outlineVariant = Color(0xFF22312C),
+
+    error = Color(0xFFFF8A72),
+    onError = Color(0xFF3B0800),
+    errorContainer = Color(0xFF5A170A),
+    onErrorContainer = Color(0xFFFFDAD6),
+
+    inverseSurface = GajaColors.Surface,
+    inverseOnSurface = GajaColors.TextPrimary,
+    inversePrimary = GajaColors.LimeDark,
+
+    scrim = Color(0xFF000000),
 )
 
+// ============================================================================
+// SECTION 2: TYPOGRAPHY
+// Clean, modern, readable type scale
+// ============================================================================
+
+/** GAJA Typography - Material 3 type scale with Korean-optimized sizing */
+private val GajaTypography = Typography(
+    // Display - Large headlines, hero sections
+    displayLarge = TextStyle(
+        fontFamily = null, // Use system default for Korean support
+        fontWeight = FontWeight.Bold,
+        fontSize = 52.sp,
+        letterSpacing = (-0.6).sp,
+        lineHeight = 58.sp,
+    ),
+    displayMedium = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 40.sp,
+        letterSpacing = 0.sp,
+        lineHeight = 46.sp,
+    ),
+    displaySmall = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 32.sp,
+        letterSpacing = 0.sp,
+        lineHeight = 38.sp,
+    ),
+    
+    // Headline - Section headers, prominent titles
+    headlineLarge = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 30.sp,
+        letterSpacing = 0.sp,
+        lineHeight = 36.sp,
+    ),
+    headlineMedium = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 26.sp,
+        letterSpacing = 0.sp,
+        lineHeight = 32.sp,
+    ),
+    headlineSmall = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 22.sp,
+        letterSpacing = (-0.1).sp,
+        lineHeight = 28.sp,
+    ),
+    
+    // Title - Card titles, important labels
+    titleLarge = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 20.sp,
+        letterSpacing = 0.sp,
+        lineHeight = 26.sp,
+    ),
+    titleMedium = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 17.sp,
+        letterSpacing = 0.05.sp,
+        lineHeight = 22.sp,
+    ),
+    titleSmall = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 15.sp,
+        letterSpacing = 0.05.sp,
+        lineHeight = 20.sp,
+    ),
+    
+    // Body - Main content text
+    bodyLarge = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 15.sp,
+        letterSpacing = 0.2.sp,
+        lineHeight = 22.sp,
+    ),
+    bodyMedium = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 13.sp,
+        letterSpacing = 0.15.sp,
+        lineHeight = 19.sp,
+    ),
+    bodySmall = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        letterSpacing = 0.2.sp,
+        lineHeight = 16.sp,
+    ),
+    
+    // Label - Buttons, chips, small labels
+    labelLarge = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 13.sp,
+        letterSpacing = 0.1.sp,
+        lineHeight = 18.sp,
+    ),
+    labelMedium = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        letterSpacing = 0.3.sp,
+        lineHeight = 16.sp,
+    ),
+    labelSmall = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 10.sp,
+        letterSpacing = 0.3.sp,
+        lineHeight = 13.sp,
+    ),
+)
+
+// ============================================================================
+// SECTION 3: SHAPE SYSTEM
+// Consistent corner radii across all components
+// ============================================================================
+
+/** GAJA Shape System - Rounded corners for a friendly, modern feel */
+private val GajaShapes = Shapes(
+    // Extra small - Chips, small buttons
+    extraSmall = RoundedCornerShape(10.dp),
+    
+    // Small - Small cards, text fields
+    small = RoundedCornerShape(14.dp),
+    
+    // Medium - Cards, dialogs
+    medium = RoundedCornerShape(20.dp),
+    
+    // Large - Large cards, bottom sheets
+    large = RoundedCornerShape(28.dp),
+    
+    // Extra large - Hero cards, full-width containers
+    extraLarge = RoundedCornerShape(36.dp),
+)
+
+// ============================================================================
+// SECTION 4: SPACING & DIMENSION TOKENS
+// Consistent spacing scale for layout
+// ============================================================================
+
+/** Spacing scale - 4dp base unit */
+object GajaSpacing {
+    val None = 0.dp
+    val ExtraSmall = 6.dp
+    val Small = 10.dp
+    val Medium = 14.dp
+    val Large = 18.dp
+    val ExtraLarge = 24.dp
+    val XXLarge = 30.dp
+    val XXXLarge = 40.dp
+    val Huge = 56.dp
+    
+    // Component-specific spacing
+    val CardPadding = 24.dp
+    val ScreenPadding = 20.dp
+    val SectionSpacing = 30.dp
+    val ItemSpacing = 14.dp
+}
+
+/** Elevation tokens - Shadow depths */
+object GajaElevation {
+    val None = 0.dp
+    val Low = 2.dp
+    val Medium = 5.dp
+    val High = 10.dp
+    val ExtraHigh = 14.dp
+    val Hero = 18.dp
+}
+
+/** Component dimensions */
+object GajaDimensions {
+    // Buttons
+    val ButtonHeight = 52.dp
+    val ButtonHeightCompact = 42.dp
+    val ButtonCornerRadius = 18.dp
+    
+    // Cards
+    val CardCornerRadius = 22.dp
+    val CardCornerRadiusLarge = 34.dp
+    
+    // Navigation
+    val NavigationBarHeight = 82.dp
+    val TopAppBarHeight = 64.dp
+    
+    // Icons
+    val IconSmall = 18.dp
+    val IconMedium = 24.dp
+    val IconLarge = 32.dp
+    
+    // Avatars
+    val AvatarSmall = 32.dp
+    val AvatarMedium = 48.dp
+    val AvatarLarge = 72.dp
+    
+    // Chips
+    val ChipHeight = 34.dp
+    val ChipCornerRadius = 18.dp
+}
+
+// ============================================================================
+// SECTION 5: COMPOSITION LOCALS
+// Provide design tokens to composition tree
+// ============================================================================
+
+/** Local spacing provider for easy access in composables */
+val LocalGajaSpacing = staticCompositionLocalOf { GajaSpacing }
+
+/** Local dimensions provider */
+val LocalGajaDimensions = staticCompositionLocalOf { GajaDimensions }
+
+/** Local elevation provider */
+val LocalGajaElevation = staticCompositionLocalOf { GajaElevation }
+
+// ============================================================================
+// SECTION 6: THEME COMPOSABLE
+// Main theme wrapper for the app
+// ============================================================================
+
+/**
+ * GAJA Theme - Material 3 theme with custom design tokens
+ * 
+ * Usage:
+ * ```kotlin
+ * GajaTheme {
+ *     // Your content here
+ * }
+ * ```
+ */
+@Composable
+fun GajaTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = GajaTypography,
+        shapes = GajaShapes,
+        content = content,
+    )
+}
+
+/**
+ * Legacy theme name for backward compatibility
+ * @deprecated Use GajaTheme instead
+ */
 @Composable
 fun BikeFrontTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    MaterialTheme(
-        colorScheme = if (darkTheme) DarkColors else LightColors,
-        content = content,
-    )
+    GajaTheme(darkTheme = darkTheme, content = content)
 }


### PR DESCRIPTION
## 작업 목적
홈, 로그인, 프로필, 라이딩 HUD 전반을 위치기반 스포츠 앱 톤으로 재정비합니다.

## 변경 내용
- 색 대비를 조정해 CTA와 로그인 텍스트 가독성을 복구했습니다.
- 홈 화면에 자유 주행 진입 히어로와 추천 코스 히어로를 추가했습니다.
- 내 정보/로그인 화면을 다크 코크핏 카드 기반으로 재설계했습니다.
- 지도 기반 라이딩 HUD 패널을 더 강한 계층과 대비로 재구성했습니다.

## 확인 방법
- `cmd.exe /c gradlew.bat :app:compileDebugKotlin :app:assembleRelease`
- release APK 생성 확인: `app/build/outputs/apk/release/app-release.apk`

## 문서 영향 범위
- current 문서는 변경하지 않았습니다.
- `DOCS/00_기준/frontend-mobile/모바일_디자인_토큰_시스템.md` 방향과 정합성을 맞췄습니다.

## self-review 결과
- 로그인 화면의 저대비 텍스트 문제를 토큰 레벨에서 먼저 해소했습니다.
- 홈/라이드/프로필이 동일한 디자인 언어로 보이도록 inverse surface와 primary hierarchy를 통일했습니다.
- 실제 에뮬레이터 smoke 캡처는 아직 수행하지 못했습니다.
