### PR TITLE
build: use api.gajabike.shop as the release base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cmd.exe /c gradlew.bat test
 ## API base URL
 
 - debug 기본값: `http://10.0.2.2:8080`
-- 현재 배포 backend 기준 base URL: `http://3.35.168.38`
+- 현재 배포 backend 기준 base URL: `https://api.gajabike.shop`
 - release URL은 환경에 따라 gradle property로 덮어씁니다.
 - 필요 시 gradle property로 덮어쓸 수 있습니다.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ configurations.configureEach {
 }
 
 def quote = { value -> "\"${value}\"" }
-def debugApiBaseUrl = providers.gradleProperty("debugApiBaseUrl").orElse("http://3.35.168.38").get()
-def releaseApiBaseUrl = providers.gradleProperty("releaseApiBaseUrl").orElse("http://3.35.168.38").get()
+def debugApiBaseUrl = providers.gradleProperty("debugApiBaseUrl").orElse("http://10.0.2.2:8080").get()
+def releaseApiBaseUrl = providers.gradleProperty("releaseApiBaseUrl").orElse("https://api.gajabike.shop").get()
 def signingPropsFile = rootProject.file("signing.local.properties")
 def signingProps = new Properties()
 def hasLocalSigning = signingPropsFile.exists()


### PR DESCRIPTION
## Summary
- switch the default release API base URL to `https://api.gajabike.shop`
- restore the Android debug default to the local emulator URL `http://10.0.2.2:8080`
- update the README to match the current production endpoint

Refs #26