### PR TITLE
feat: refresh BIKE frontend copy and use deployed debug backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cmd.exe /c gradlew.bat test
 
 ## API base URL
 
-- debug 기본값: `http://10.0.2.2:8080`
+- debug 기본값: `https://api.gajabike.shop`
 - 현재 배포 backend 기준 base URL: `https://api.gajabike.shop`
 - release URL은 환경에 따라 gradle property로 덮어씁니다.
 - 필요 시 gradle property로 덮어쓸 수 있습니다.
@@ -120,7 +120,7 @@ cmd.exe /c gradlew.bat test
 
 ## Device APK note
 
-- 실제 Android 기기에 debug APK를 설치할 때는 기본 `10.0.2.2` 주소를 그대로 쓰면 안 됩니다.
+- 예전 emulator-local 기본값 `10.0.2.2` 대신 현재는 운영 backend URL을 debug 기본값으로 사용합니다.
 - 실기기 설치용 debug APK는 접근 가능한 운영 또는 staging URL로 다시 빌드합니다.
 - 기본 debug APK 경로: `app/build/outputs/apk/debug/app-debug.apk`
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ configurations.configureEach {
 }
 
 def quote = { value -> "\"${value}\"" }
-def debugApiBaseUrl = providers.gradleProperty("debugApiBaseUrl").orElse("http://10.0.2.2:8080").get()
+def debugApiBaseUrl = providers.gradleProperty("debugApiBaseUrl").orElse("https://api.gajabike.shop").get()
 def releaseApiBaseUrl = providers.gradleProperty("releaseApiBaseUrl").orElse("https://api.gajabike.shop").get()
 def signingPropsFile = rootProject.file("signing.local.properties")
 def signingProps = new Properties()

--- a/app/src/main/java/com/bikeprojectminji/bikefront/auth/AuthProfileActivity.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/auth/AuthProfileActivity.kt
@@ -16,8 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
@@ -33,7 +32,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.foundation.text.KeyboardOptions
 import com.bikeprojectminji.bikefront.ui.screen.GajaBrandTopBar
+import com.bikeprojectminji.bikefront.ui.screen.GajaSectionCard
+import com.bikeprojectminji.bikefront.ui.screen.GajaStatusBadge
 import com.bikeprojectminji.bikefront.ui.screen.GajaPrimaryButton
 import com.bikeprojectminji.bikefront.ui.screen.SecondaryActionButton
 import com.bikeprojectminji.bikefront.ui.screen.SectionHeader
@@ -247,7 +251,7 @@ fun AuthProfileScreen(returnAfterSave: Boolean, onFinish: () -> Unit, onSaved: (
     }
 
     Scaffold(
-        topBar = { GajaBrandTopBar(title = "프로필") },
+        topBar = { GajaBrandTopBar(title = if (sessionSnapshot.signedIn) "내 계정" else "로그인") },
         containerColor = GajaColors.Background,
     ) { innerPadding ->
         Column(
@@ -259,11 +263,16 @@ fun AuthProfileScreen(returnAfterSave: Boolean, onFinish: () -> Unit, onSaved: (
         ) {
             Spacer(Modifier.height(GajaSpacing.Small))
 
-            Text(
-                text = helperMessage,
-                style = MaterialTheme.typography.bodyMedium,
-                color = GajaColors.TextSecondary,
-            )
+            GajaSectionCard(
+                containerColor = GajaColors.SurfaceMuted,
+                shape = RoundedCornerShape(GajaSpacing.Large),
+            ) {
+                Text(
+                    text = helperMessage,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = GajaColors.TextSecondary,
+                )
+            }
 
             if (sessionSnapshot.signedIn) {
                 SignedInSessionContent(
@@ -337,19 +346,39 @@ private fun LoggedOutLoginContent(
     onSubmit: () -> Unit,
     onClose: () -> Unit,
 ) {
+    GajaSectionCard(
+        containerColor = GajaColors.PrimarySoft,
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(GajaSpacing.Large),
+    ) {
+        Text(
+            text = if (authMode == AuthMode.LOGIN) "이메일로 바로 시작" else "간단히 가입하고 이어서 이용",
+            style = MaterialTheme.typography.titleLarge,
+            color = GajaColors.TextPrimary,
+        )
+        Text(
+            text = if (authMode == AuthMode.LOGIN) {
+                if (returnAfterSave) "로그인 후 저장 중이던 코스 흐름으로 바로 돌아갑니다." else "필요한 정보만 입력하면 바로 라이딩 기록을 이어갈 수 있어요."
+            } else {
+                if (returnAfterSave) "가입을 마치면 저장 중이던 흐름으로 곧바로 돌아갑니다." else "표시 이름까지 입력하면 바로 이용을 시작할 수 있어요."
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = GajaColors.TextSecondary,
+        )
+    }
+
     SectionHeader(
         title = if (authMode == AuthMode.LOGIN) "로그인" else "회원가입",
         subtitle = if (authMode == AuthMode.LOGIN) {
             if (returnAfterSave) {
-                "기존 계정으로 로그인하고 저장 중이던 코스 흐름을 바로 이어갑니다."
+                "기존 계정으로 바로 이어가기"
             } else {
-                "이메일/비밀번호로 세션을 만들고 갱신합니다."
+                "이메일로 빠르게 시작"
             }
         } else {
             if (returnAfterSave) {
-                "새 계정을 만든 뒤 바로 코스 저장과 공유 흐름으로 돌아갑니다."
+                "가입 후 저장 흐름으로 돌아가기"
             } else {
-                "새 계정을 만든 뒤 바로 프로필 세션을 저장합니다."
+                "기본 정보만 입력하고 시작"
             }
         },
     )
@@ -402,6 +431,8 @@ private fun LoggedOutLoginContent(
         label = { Text("비밀번호") },
         placeholder = { Text("비밀번호를 입력하세요") },
         enabled = !inFlight,
+        visualTransformation = PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
         shape = MaterialTheme.shapes.medium,
         colors = outlinedFieldColors(),
     )
@@ -439,32 +470,28 @@ private fun SignedInSessionContent(
 ) {
     SectionHeader(
         title = "계정 상태",
-        subtitle = if (sessionSnapshot.needsRefresh) "access token이 만료되어 refresh로 갱신할 수 있습니다." else "현재 세션이 저장되어 있습니다.",
+        subtitle = if (sessionSnapshot.needsRefresh) "로그인 상태를 한 번 새로 확인해 주세요." else "현재 계정으로 저장과 공유를 이어갈 수 있어요.",
     )
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = GajaColors.White),
-    ) {
-        Column(
-            modifier = Modifier.padding(GajaSpacing.Large),
-            verticalArrangement = Arrangement.spacedBy(GajaSpacing.Small),
-        ) {
-            Text(sessionSnapshot.displayName, style = MaterialTheme.typography.headlineSmall, color = GajaColors.TextPrimary)
-            Text(
-                text = if (sessionSnapshot.profileImageUrl.isBlank()) "프로필 이미지 URL이 아직 없습니다." else sessionSnapshot.profileImageUrl,
-                style = MaterialTheme.typography.bodySmall,
-                color = GajaColors.TextSecondary,
-            )
-            SessionStatusRow("세션 상태", if (sessionSnapshot.hasUsableAccessToken) "즉시 사용 가능" else "갱신 필요")
-            SessionStatusRow("access 만료 시각", sessionSnapshot.accessExpiryText)
-            SessionStatusRow("refresh 만료 시각", sessionSnapshot.refreshExpiryText)
+    GajaSectionCard(contentPadding = androidx.compose.foundation.layout.PaddingValues(GajaSpacing.Large)) {
+        Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+            Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Tiny)) {
+                Text(sessionSnapshot.displayName, style = MaterialTheme.typography.headlineSmall, color = GajaColors.TextPrimary)
+                Text(
+                    text = if (sessionSnapshot.hasUsableAccessToken) "현재 계정으로 바로 이용할 수 있어요." else "다시 확인하면 안전하게 이어서 이용할 수 있어요.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = GajaColors.TextSecondary,
+                )
+            }
+            GajaStatusBadge(text = if (sessionSnapshot.needsRefresh) "재확인 필요" else "이용 가능")
         }
+
+        SessionStatusRow("세션 상태", if (sessionSnapshot.hasUsableAccessToken) "바로 이용 가능" else "새로 확인 필요")
+        SessionStatusRow("프로필 이미지", if (sessionSnapshot.profileImageUrl.isBlank()) "아직 없음" else "연결됨")
     }
 
     GajaPrimaryButton(
-        text = if (inFlight) "세션 처리 중..." else if (sessionSnapshot.needsRefresh) "세션 갱신" else "세션 다시 확인",
+        text = if (inFlight) "확인 중..." else if (sessionSnapshot.needsRefresh) "로그인 상태 새로 확인" else "계속 이용하기",
         onClick = onRefresh,
         enabled = !inFlight,
     )

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CommonUi.kt
@@ -44,7 +44,7 @@ fun GajaBrandTopBar(
             Text(
                 text = title,
                 style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Black,
+                fontWeight = FontWeight.SemiBold,
                 color = GajaColors.TextPrimary
             )
         },
@@ -54,14 +54,14 @@ fun GajaBrandTopBar(
                 onProfileClick != null -> {
                     Surface(
                         shape = CircleShape,
-                        color = GajaColors.Surface,
+                        color = GajaColors.SurfaceMuted,
                         border = BorderStroke(1.dp, GajaColors.Border),
                     ) {
                         IconButton(onClick = onProfileClick, modifier = Modifier.size(GajaControlTokens.TopBarAction)) {
                             Icon(
                                 imageVector = Icons.Default.AccountCircle,
-                                contentDescription = "Profile",
-                                tint = GajaColors.TextPrimary,
+                                contentDescription = "내 정보",
+                                tint = GajaColors.Accent,
                                 modifier = Modifier.size(GajaIconSizes.Large)
                             )
                         }
@@ -91,7 +91,7 @@ fun GajaPrimaryButton(
         modifier = modifier
             .fillMaxWidth()
             .height(GajaButtonTokens.Height),
-        shape = RoundedCornerShape(GajaRadius.Medium),
+        shape = RoundedCornerShape(GajaRadius.Large),
         colors = ButtonDefaults.buttonColors(
             containerColor = containerColor,
             contentColor = GajaColors.White,
@@ -182,7 +182,7 @@ fun GajaSectionCard(
         contentColor = contentColor,
         border = BorderStroke(GajaCardTokens.BorderWidth, borderColor),
         tonalElevation = tonalElevation,
-        shadowElevation = shadowElevation,
+        shadowElevation = if (shadowElevation == 0.dp) GajaCardTokens.SubtleElevation else shadowElevation,
     ) {
         Column(
             modifier = Modifier.padding(contentPadding),
@@ -225,7 +225,7 @@ fun GajaMetricCard(
     icon: ImageVector? = null,
     emphasized: Boolean = false,
     supportingText: String? = null,
-    containerColor: Color = if (emphasized) GajaColors.PrimaryContainer else GajaColors.Background,
+    containerColor: Color = if (emphasized) GajaColors.PrimaryContainer else GajaColors.SurfaceMuted,
     contentColor: Color = GajaColors.TextPrimary,
 ) {
     Surface(
@@ -322,7 +322,7 @@ fun HeroCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     icon: String? = null,
-    gradientColors: List<Color> = listOf(GajaColors.Carbon, GajaColors.Accent)
+    gradientColors: List<Color> = GajaColors.HeroGradient,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -338,22 +338,23 @@ fun HeroCard(
             Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Medium)) {
                 if (icon != null) {
                     GajaStatusBadge(
-                        text = icon.uppercase(),
-                        containerColor = GajaColors.White.copy(alpha = 0.14f),
-                        contentColor = GajaColors.White,
+                        text = icon,
+                        containerColor = GajaColors.White.copy(alpha = 0.8f),
+                        contentColor = GajaColors.Accent,
                     )
                 }
                 
                 Column {
-                    Text(title, style = MaterialTheme.typography.headlineMedium, color = Color.White, fontWeight = FontWeight.Bold)
+                    Text(title, style = MaterialTheme.typography.headlineMedium, color = GajaColors.TextPrimary, fontWeight = FontWeight.Bold)
                     Spacer(Modifier.height(GajaSpacing.Micro))
-                    Text(description, style = MaterialTheme.typography.bodyMedium, color = Color.White.copy(alpha = 0.7f))
+                    Text(description, style = MaterialTheme.typography.bodyMedium, color = GajaColors.TextSecondary)
                 }
 
                 GajaPrimaryButton(
                     text = buttonText,
                     onClick = onClick,
                     icon = Icons.AutoMirrored.Filled.ArrowForward,
+                    containerColor = GajaColors.Accent,
                 )
             }
         }
@@ -368,7 +369,7 @@ fun CourseCard(
     Surface(
         modifier = Modifier.fillMaxWidth().clickable { onClick() },
         shape = RoundedCornerShape(GajaRadius.Medium),
-        color = GajaColors.White,
+        color = GajaColors.Surface,
         border = BorderStroke(1.dp, GajaColors.Border)
     ) {
         Row(
@@ -380,13 +381,13 @@ fun CourseCard(
                 modifier = Modifier
                     .size(GajaControlTokens.LargeListLeading)
                     .clip(RoundedCornerShape(GajaRadius.Small))
-                    .background(GajaColors.Background),
+                    .background(GajaColors.PrimarySoft),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     imageVector = GajaIconTokens.Course, 
                     contentDescription = null, 
-                    tint = GajaColors.TextPrimary, 
+                    tint = GajaColors.Accent, 
                     modifier = Modifier.size(GajaIconSizes.PrimaryControl)
                 )
             }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursePreRideScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursePreRideScreen.kt
@@ -192,7 +192,7 @@ fun CoursePreRideScreen(
             .padding(horizontal = GajaSpacing.ScreenPadding, vertical = GajaSpacing.Small),
         verticalArrangement = Arrangement.spacedBy(GajaSpacing.SectionGap),
     ) {
-        GajaBrandTopBar(title = "경로 미리보기")
+        GajaBrandTopBar(title = "코스 미리보기")
 
         Surface(
             modifier = Modifier.fillMaxWidth(),
@@ -234,7 +234,7 @@ fun CoursePreRideScreen(
                         modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.spacedBy(GajaSpacing.Tiny),
                     ) {
-                        GajaStatusBadge(text = "추천 코스")
+                        GajaStatusBadge(text = "추천")
                         Text(
                             resolvedCourse.title,
                             style = MaterialTheme.typography.titleLarge,
@@ -280,13 +280,13 @@ fun CoursePreRideScreen(
             Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Small)) {
                 Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Micro)) {
                     Text(
-                        text = "퍼포먼스 시작 준비",
+                        text = "출발 전 확인",
                         style = MaterialTheme.typography.labelSmall,
                         color = GajaColors.Primary,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
-                        text = "출발 전에 상태를 확인하고 바로 주행으로 이어집니다.",
+                        text = "현재 위치와 시작 가능 여부를 확인한 뒤 바로 주행으로 이어집니다.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.White.copy(alpha = 0.74f),
                     )

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesRepository.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesRepository.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import android.content.Context
 import com.bikeprojectminji.bikefront.auth.AuthSessionStore
 import com.bikeprojectminji.bikefront.config.AppConfig
-import com.bikeprojectminji.bikefront.course.RecordedCourseStore
 import com.bikeprojectminji.bikefront.course.RecordedCourseItem
+import com.bikeprojectminji.bikefront.course.RecordedCourseStore
 import com.bikeprojectminji.bikefront.home.FeaturedCourseApiClient
 import org.json.JSONObject
 import java.io.BufferedReader

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/CoursesScreen.kt
@@ -21,6 +21,13 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.bikeprojectminji.bikefront.ui.screen.CourseCard
+import com.bikeprojectminji.bikefront.ui.screen.EmptyStateView
+import com.bikeprojectminji.bikefront.ui.screen.ErrorStateView
+import com.bikeprojectminji.bikefront.ui.screen.GajaBrandTopBar
+import com.bikeprojectminji.bikefront.ui.screen.GajaSectionCard
+import com.bikeprojectminji.bikefront.ui.screen.LoadingStateView
+import com.bikeprojectminji.bikefront.ui.screen.SectionHeader
 import com.bikeprojectminji.bikefront.ui.theme.GajaColors
 import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +35,7 @@ import kotlinx.coroutines.withContext
 
 private enum class CourseTab(val label: String, val description: String) {
     RECOMMENDED("추천", "엄선된 인기 코스"),
-    ALL("전체", "모든 코스 둘러보기"),
+    ALL("전체", "공개 코스 둘러보기"),
 }
 
 private sealed class CoursesLoadState {
@@ -95,6 +102,7 @@ fun CoursesScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .padding(innerPadding)
                     .padding(horizontal = GajaSpacing.ScreenPadding),
                 verticalArrangement = Arrangement.spacedBy(GajaSpacing.SectionGap)
             ) {
@@ -110,7 +118,16 @@ fun CoursesScreen(
                     onTabSelected = { selectedTab = it },
                 )
 
-                val loadState = if (selectedTab == CourseTab.RECOMMENDED) featuredState.value else allCoursesState.value
+                Text(
+                    text = "추천에서는 엄선된 코스를, 전체에서는 공개된 코스를 함께 볼 수 있어요.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = GajaColors.TextSecondary,
+                )
+
+                val loadState = when (selectedTab) {
+                    CourseTab.RECOMMENDED -> featuredState.value
+                    CourseTab.ALL -> allCoursesState.value
+                }
 
                 AnimatedVisibility(
                     visible = true,
@@ -125,7 +142,7 @@ fun CoursesScreen(
                             if (loadState.courses.isEmpty()) {
                                 EmptyStateView("결과 없음", "표시할 코스가 없습니다.")
                             } else {
-                                CourseListContent(loadState.courses, selectedTab, onOpenCourse)
+                                CourseListContent(loadState.courses, onOpenCourse)
                             }
                         }
                     }
@@ -175,7 +192,6 @@ private fun CourseTabSelector(selectedTab: CourseTab, onTabSelected: (CourseTab)
 @Composable
 private fun CourseListContent(
     courses: List<CourseCardUiModel>,
-    selectedTab: CourseTab,
     onOpenCourse: (CourseCardUiModel) -> Unit,
 ) {
     LazyColumn(verticalArrangement = Arrangement.spacedBy(GajaSpacing.ItemSpacing)) {

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/FreeRidePreRideScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/FreeRidePreRideScreen.kt
@@ -74,17 +74,17 @@ fun FreeRidePreRideScreen(
                 ) {
                     Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Small)) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            FreeRideStatusBadge(text = "LIVE", containerColor = GajaColors.Primary)
-                            FreeRideStatusBadge(text = "GPS 준비", containerColor = GajaColors.Success)
+                            FreeRideStatusBadge(text = "바로 출발", containerColor = GajaColors.Primary)
+                            FreeRideStatusBadge(text = "위치 기반", containerColor = GajaColors.Success)
                         }
                         Text(
-                            text = "지금 바로 자유 주행",
+                            text = "가볍게 자유 주행 시작",
                             style = MaterialTheme.typography.displayMedium,
                             color = GajaColors.TextPrimary,
                             fontWeight = FontWeight.Black,
                         )
                         Text(
-                            text = "현재 위치를 기준으로 출발하고, 기록을 저장해 코스로 이어갈 수 있습니다.",
+                            text = "현재 위치를 기준으로 출발하고 주행 기록을 저장할 수 있어요.",
                             style = MaterialTheme.typography.bodyLarge,
                             color = GajaColors.TextSecondary,
                         )
@@ -92,8 +92,8 @@ fun FreeRidePreRideScreen(
                 }
 
                 Row(horizontalArrangement = Arrangement.spacedBy(GajaSpacing.ItemSpacing), modifier = Modifier.fillMaxWidth()) {
-                    GajaMetricCard(label = "지도", value = "실시간", modifier = Modifier.weight(1f), emphasized = true)
-                    GajaMetricCard(label = "기록", value = "저장 가능", modifier = Modifier.weight(1f))
+                    GajaMetricCard(label = "주행 화면", value = "실시간", modifier = Modifier.weight(1f), emphasized = true)
+                    GajaMetricCard(label = "기록", value = "자동 저장 준비", modifier = Modifier.weight(1f))
                 }
             }
 
@@ -108,13 +108,13 @@ fun FreeRidePreRideScreen(
                     contentPadding = PaddingValues(horizontal = GajaCardTokens.DefaultPadding, vertical = GajaSpacing.Small),
                 ) {
                     Text(
-                        text = "주행 중에는 속도, 거리, 날씨, 주행 상태를 지도 위 HUD로 바로 확인할 수 있습니다.",
+                        text = "주행 중에는 지도 위에서 속도와 상태를 바로 확인할 수 있어요.",
                         style = MaterialTheme.typography.bodySmall,
                         color = GajaColors.TextSecondary,
                     )
                 }
                 GajaPrimaryButton(
-                    text = "주행 시작",
+                    text = "자유 주행 시작",
                     onClick = {
                         analyticsTracker.track("ride_start_clicked", "free_ride_pre", mapOf("button" to "start_ride"))
                         onStartRide()

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/MyInfoScreen.kt
@@ -161,24 +161,24 @@ fun MyInfoScreen(
 fun NotLoggedInContent(onOpenProfile: () -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.Large)) {
         HeroCard(
-            title = "성장을 기록하세요",
-            description = "로그인하면 저장한 코스와 주행 기록을 한곳에서 이어서 볼 수 있어요.",
+            title = "로그인하고 기록을 이어가세요",
+            description = "저장한 코스와 주행 기록을 같은 계정에서 차분하게 관리할 수 있어요.",
             buttonText = "로그인 / 회원가입",
             onClick = onOpenProfile,
-            icon = "계정 연결"
+            icon = "계정"
         )
 
         ActivityRow(
             icon = GajaIconTokens.Profile,
-            title = "로그인 / 회원가입",
-            desc = "내 기록과 저장한 코스를 같은 계정으로 이어서 관리하기",
+            title = "내 계정 연결",
+            desc = "저장한 코스와 주행 이력을 한곳에서 관리",
             onClick = onOpenProfile,
         )
 
-        SectionHeader(title = "로그인하면 바로 할 수 있는 일", subtitle = "필요한 기능만 간단히 안내해 드려요")
+        SectionHeader(title = "로그인 후 바로 되는 일", subtitle = "지금 필요한 기능만 간단히 정리했어요")
         
         Column(verticalArrangement = Arrangement.spacedBy(GajaSpacing.ItemSpacing)) {
-            listOf("주행 경로 저장 및 공유", "상세 주행 통계 분석", "나만의 코스 만들기", "라이딩 이력 관리").forEach { text ->
+            listOf("주행 기록 저장", "내 코스 관리", "라이딩 이력 확인").forEach { text ->
                 GajaSectionCard(contentPadding = PaddingValues(GajaCardTokens.DefaultPadding)) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -209,16 +209,16 @@ private fun ProfileContent(
                     horizontalArrangement = Arrangement.spacedBy(GajaSpacing.Medium),
                 ) {
                     Box(
-                        modifier = Modifier.size(58.dp).clip(CircleShape).background(GajaColors.Carbon),
+                        modifier = Modifier.size(58.dp).clip(CircleShape).background(GajaColors.PrimaryContainer),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Text(state.displayName.take(1).uppercase(), style = MaterialTheme.typography.headlineMedium, color = GajaColors.White)
+                        Text(state.displayName.take(1).uppercase(), style = MaterialTheme.typography.headlineMedium, color = GajaColors.Accent)
                     }
                     Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         Text(state.displayName, style = MaterialTheme.typography.titleLarge, color = GajaColors.TextPrimary, fontWeight = FontWeight.Bold)
-                        Text("라이딩 통계 대시보드", style = MaterialTheme.typography.bodySmall, color = GajaColors.TextSecondary)
+                        Text("내 라이딩 요약", style = MaterialTheme.typography.bodySmall, color = GajaColors.TextSecondary)
                     }
-                    GajaStatusBadge(text = "프로필")
+                    GajaStatusBadge(text = "이용 중")
                 }
 
                 Row(
@@ -232,7 +232,7 @@ private fun ProfileContent(
             }
         }
 
-        SectionHeader(title = "종합 통계", subtitle = "전체 기록을 빠르게 훑을 수 있게 밀도를 높였어요")
+        SectionHeader(title = "종합 통계", subtitle = "전체 기록을 한눈에 확인할 수 있어요")
         state.summaryErrorMessage?.let { message ->
             GajaSectionCard {
                 Text(
@@ -244,7 +244,7 @@ private fun ProfileContent(
         }
         if (state.isWeeklySummaryEmpty) {
             Text(
-                text = "이번 주 활동은 아직 비어 있습니다.",
+                text = "이번 주 기록이 아직 없어요.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = GajaColors.TextSecondary,
             )
@@ -259,7 +259,7 @@ private fun ProfileContent(
             DashboardMetricCard("평균 속도", state.avgSpeed, Modifier.weight(1f))
         }
 
-        SectionHeader(title = "바로가기", subtitle = "기록 아래에서 바로 다음 행동으로 이어지게 정리했어요")
+        SectionHeader(title = "바로가기", subtitle = "자주 보는 화면만 모아두었어요")
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             CompactShortcutRow(
                 icon = GajaIconTokens.Saved,
@@ -281,7 +281,7 @@ private fun ProfileContent(
             )
         }
 
-        SectionHeader(title = "설정")
+        SectionHeader(title = "계정")
         GajaPrimaryButton("프로필 수정", onClick = onOpenProfile)
         SecondaryActionButton("로그아웃", onClick = { /* TODO */ })
     }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/RideStartScreen.kt
@@ -6,10 +6,8 @@ import com.bikeprojectminji.bikefront.analytics.AnalyticsTracker
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
@@ -20,15 +18,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -37,9 +32,7 @@ import com.bikeprojectminji.bikefront.auth.AuthSessionStore
 import com.bikeprojectminji.bikefront.auth.HttpAuthLoginGateway
 import com.bikeprojectminji.bikefront.ui.theme.GajaCardTokens
 import com.bikeprojectminji.bikefront.ui.theme.GajaColors
-import com.bikeprojectminji.bikefront.ui.theme.GajaControlTokens
 import com.bikeprojectminji.bikefront.ui.theme.GajaIconSizes
-import com.bikeprojectminji.bikefront.ui.theme.GajaRadius
 import com.bikeprojectminji.bikefront.ui.theme.GajaSpacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -112,7 +105,7 @@ fun RideStartScreen(
     }
 
     Scaffold(
-        topBar = { GajaBrandTopBar(title = "탐색", onProfileClick = onOpenMyInfo) },
+        topBar = { GajaBrandTopBar(title = "홈", onProfileClick = onOpenMyInfo) },
         containerColor = GajaColors.Background
     ) { scaffoldPadding ->
         Column(
@@ -123,22 +116,15 @@ fun RideStartScreen(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(GajaSpacing.SectionGap)
         ) {
-            // 1. 요약 대시보드
             Box(modifier = Modifier.padding(horizontal = GajaSpacing.ScreenPadding)) {
                 ActivitySummaryDashboard(activitySummaryState)
             }
 
-            // 2. 가로 스크롤 추천 섹션
             Column {
                 SectionHeader(
-                    title = "인기 라이딩 경로",
-                    subtitle = "많이 찾는 코스부터 가볍게 골라보세요",
+                    title = "추천 코스",
+                    subtitle = "지금 바로 출발하기 좋은 코스를 골라보세요",
                     modifier = Modifier.padding(horizontal = GajaSpacing.ScreenPadding),
-                    action = {
-                        TextButton(onClick = { }) {
-                            Text("전체 보기", color = GajaColors.Primary, fontWeight = FontWeight.Bold)
-                        }
-                    }
                 )
                 
                 Row(
@@ -160,14 +146,12 @@ fun RideStartScreen(
                 }
             }
 
-            // 3. 중앙 액션 버튼 (한글화 및 강조)
             Box(modifier = Modifier.padding(horizontal = GajaSpacing.ScreenPadding)) {
                 CompactFreeRidePanel(onStartFreeRide = onStartFreeRide)
             }
 
-            // 4. 리스트형 주변 코스
             Column(modifier = Modifier.padding(horizontal = GajaSpacing.ScreenPadding)) {
-                SectionHeader(title = "내 주변 코스", subtitle = "지금 위치에서 시작하기 좋은 코스를 모았어요")
+                SectionHeader(title = "근처에서 시작하기 좋은 코스", subtitle = "길게 고르지 않고 바로 출발할 수 있게 정리했어요")
 
                 when (val state = listState) {
                     is SectionState.Loading -> LoadingStateView("주변 코스를 찾는 중")
@@ -193,11 +177,11 @@ fun ActivitySummaryDashboard(state: RideStartActivitySummaryState) {
         when (state) {
             RideStartActivitySummaryState.Loading -> LoadingStateView("이번 주 기록을 불러오는 중")
             is RideStartActivitySummaryState.SignedOut -> SummaryMessageContent(
-                title = "이번 주 나의 활동",
+                title = "라이딩 요약",
                 message = state.message,
             )
             is RideStartActivitySummaryState.Error -> SummaryMessageContent(
-                title = "이번 주 나의 활동",
+                title = "라이딩 요약",
                 message = state.message,
             )
             is RideStartActivitySummaryState.Ready -> {
@@ -210,7 +194,7 @@ fun ActivitySummaryDashboard(state: RideStartActivitySummaryState) {
                         verticalAlignment = Alignment.Top,
                     ) {
                         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                            Text("이번 주 활동", style = MaterialTheme.typography.labelSmall, color = GajaColors.TextSecondary)
+                            Text("이번 주 라이딩", style = MaterialTheme.typography.labelSmall, color = GajaColors.TextSecondary)
                             Row(verticalAlignment = Alignment.Bottom) {
                                 Text(
                                     state.primaryDistanceText,
@@ -227,7 +211,7 @@ fun ActivitySummaryDashboard(state: RideStartActivitySummaryState) {
                             }
                         }
 
-                        GajaStatusBadge(text = state.rideCountText)
+                        GajaStatusBadge(text = "${state.rideCountText} 진행")
                     }
 
                     Text(state.helperText, style = MaterialTheme.typography.bodyMedium, color = GajaColors.TextSecondary)
@@ -276,18 +260,18 @@ private fun CompactFreeRidePanel(
                     verticalArrangement = Arrangement.spacedBy(GajaSpacing.Micro),
                 ) {
                     GajaStatusBadge(
-                        text = "자유 주행",
-                        containerColor = GajaColors.Primary.copy(alpha = 0.16f),
-                        contentColor = GajaColors.Primary,
+                        text = "바로 출발",
+                        containerColor = GajaColors.PrimaryContainer,
+                        contentColor = GajaColors.Accent,
                     )
                     Text(
-                        text = "코스 없이 바로 출발",
+                        text = "코스 없이 가볍게 시작",
                         style = MaterialTheme.typography.titleLarge,
                         color = GajaColors.White,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
-                        text = "현재 위치에서 HUD를 켜고 바로 기록을 시작할 수 있어요.",
+                        text = "현재 위치에서 바로 주행을 켜고 기록을 남길 수 있어요.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = GajaColors.White.copy(alpha = 0.74f),
                     )
@@ -307,7 +291,7 @@ private fun CompactFreeRidePanel(
             ) {
                 CompactStatusPill(text = "즉시 시작", modifier = Modifier.weight(1f))
                 CompactStatusPill(text = "기록 저장", modifier = Modifier.weight(1f))
-                CompactStatusPill(text = "HUD 진입", modifier = Modifier.weight(1f))
+                CompactStatusPill(text = "주행 화면", modifier = Modifier.weight(1f))
             }
 
             GajaPrimaryButton(
@@ -348,7 +332,7 @@ fun FeaturedCourseGridItem(course: CourseCardUiModel, onClick: () -> Unit) {
                 Spacer(Modifier.height(GajaSpacing.Tiny))
                 Text(course.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, maxLines = 2, overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis)
                 Text(
-                    text = "탭해서 코스 미리보기",
+                    text = "출발 전 확인",
                     style = MaterialTheme.typography.bodySmall,
                     color = GajaColors.TextSecondary,
                     maxLines = 1,

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/SplashScreen.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/screen/SplashScreen.kt
@@ -1,18 +1,20 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
 import androidx.compose.animation.core.*
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -40,7 +42,11 @@ fun SplashScreen(onAnimationFinished: () -> Unit) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    colors = GajaColors.BrandGradient
+                    colors = listOf(
+                        GajaColors.LimeAccent,
+                        GajaColors.BrandGradient.first(),
+                        GajaColors.BrandGradient.last(),
+                    )
                 )
             ),
         contentAlignment = Alignment.Center
@@ -50,31 +56,39 @@ fun SplashScreen(onAnimationFinished: () -> Unit) {
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.graphicsLayer { alpha = alphaAnim.value }
         ) {
-            // GAJA Brand Icon (Bike Pictogram)
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.DirectionsBike,
-                contentDescription = "GAJA Logo",
+            Surface(
                 modifier = Modifier.size(120.dp),
-                tint = GajaColors.Accent
-            )
-            
+                shape = CircleShape,
+                color = GajaColors.White.copy(alpha = 0.86f),
+                border = BorderStroke(1.dp, GajaColors.White.copy(alpha = 0.55f)),
+                shadowElevation = 10.dp,
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.DirectionsBike,
+                        contentDescription = "gaja 로고",
+                        modifier = Modifier.size(52.dp),
+                        tint = GajaColors.Accent
+                    )
+                }
+            }
+
             Spacer(modifier = Modifier.height(24.dp))
-            
-            // GAJA Brand Text
+
             Text(
-                text = "GAJA",
+                text = "gaja",
                 style = MaterialTheme.typography.displayLarge.copy(
-                    fontSize = 56.sp,
-                    letterSpacing = 6.sp,
-                    fontWeight = FontWeight.Black,
-                    color = Color.White
+                    fontSize = 44.sp,
+                    letterSpacing = (-1.2).sp,
+                    fontWeight = FontWeight.Bold,
+                    color = GajaColors.TextPrimary
                 )
             )
-            
+
             Text(
-                text = "Ride Your Discovery",
+                text = "가볍게 떠나는 자전거 이동",
                 style = MaterialTheme.typography.labelLarge,
-                color = GajaColors.LimeAccent.copy(alpha = 0.9f),
+                color = GajaColors.TextSecondary,
                 modifier = Modifier.padding(top = 12.dp)
             )
         }

--- a/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
+++ b/app/src/main/java/com/bikeprojectminji/bikefront/ui/theme/Theme.kt
@@ -1,214 +1,233 @@
 package com.bikeprojectminji.bikefront.ui.theme
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.material3.Typography
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Shapes
-import androidx.compose.material3.Typography
-
-// ============================================================================
-// Premium Mobility & Action Design System
-// High-contrast, sharp, Lime/Electric Mobility-inspired look
-// ============================================================================
+import com.bikeprojectminji.bikefront.R
 
 object GajaColors {
-    // Primary: Electric Green
-    val Primary = Color(0xFF00D05A) 
+    val Primary = Color(0xFF5F8F6B)
     val OnPrimary = Color(0xFFFFFFFF)
-    val PrimaryContainer = Color(0xFFE5FAE8)
-    
-    // Accent: Sleek Dark
-    val Accent = Color(0xFF111111)
-    val LimeAccent = Color(0xFFF0F0F0)
-    val BrightLime = Color(0xFFEAEAEA)
-    
-    // Neutrals
-    val White = Color(0xFFFFFFFF)
-    val Background = Color(0xFFF7F7FD) // Pure mobility gray-white
-    val Surface = Color(0xFFFFFFFF)
-    
-    // Text: High Contrast
-    val TextPrimary = Color(0xFF111111) // Deep Black
-    val TextSecondary = Color(0xFF555555) // Neutral Gray
-    val TextTertiary = Color(0xFF888888) // Light Gray
-    
-    // UI Helpers 
-    val Carbon = Color(0xFF1A1A1A) 
-    val Graphite = Color(0xFF333333)
-    
-    // Semantic
-    val Success = Color(0xFF00D05A)
-    val Warning = Color(0xFFFFB703)
-    val Error = Color(0xFFDE3226)
+    val PrimaryContainer = Color(0xFFE4F0E4)
+    val PrimarySoft = Color(0xFFF1F6EF)
 
-    // Layout
-    val Border = Color(0xFFEBEBEB)
-    val Divider = Color(0xFFF2F2F2)
-    
-    // Brand Gradients 
-    val BrandGradient = listOf(Color(0xFF00D05A), Color(0xFF009C43))
+    val Accent = Color(0xFF294034)
+    val AccentSoft = Color(0xFF385344)
+    val LimeAccent = Color(0xFFF8FBF6)
+    val BrightLime = Color(0xFFEFF6EC)
+
+    val White = Color(0xFFFFFFFF)
+    val Background = Color(0xFFF5F7F2)
+    val Surface = Color(0xFFFFFEFB)
+    val SurfaceMuted = Color(0xFFF7FAF5)
+
+    val TextPrimary = Color(0xFF24342B)
+    val TextSecondary = Color(0xFF5C6C61)
+    val TextTertiary = Color(0xFF8A948D)
+
+    val Carbon = Color(0xFF304437)
+    val Graphite = Color(0xFF4A6254)
+
+    val Success = Color(0xFF5A8A63)
+    val Warning = Color(0xFFC78B46)
+    val Error = Color(0xFFC85B50)
+
+    val Border = Color(0xFFDCE5D8)
+    val Divider = Color(0xFFEBF1E8)
+
+    val BrandGradient = listOf(Color(0xFFEAF4E7), Color(0xFFD8EAD8))
+    val HeroGradient = listOf(Color(0xFFF5FAF2), Color(0xFFE2EFE1))
 }
 
 private val LightColorScheme = lightColorScheme(
     primary = GajaColors.Primary,
     onPrimary = GajaColors.White,
     primaryContainer = GajaColors.PrimaryContainer,
-    onPrimaryContainer = GajaColors.Primary,
-    
+    onPrimaryContainer = GajaColors.Accent,
+
     secondary = GajaColors.Accent,
     onSecondary = GajaColors.White,
-    
+
     background = GajaColors.Background,
     onBackground = GajaColors.TextPrimary,
-    
-    surface = GajaColors.White,
+
+    surface = GajaColors.Surface,
     onSurface = GajaColors.TextPrimary,
-    surfaceVariant = GajaColors.Divider,
+    surfaceVariant = GajaColors.SurfaceMuted,
     onSurfaceVariant = GajaColors.TextSecondary,
-    
+
     outline = GajaColors.Border,
     error = GajaColors.Error,
 )
 
 private val DarkColorScheme = darkColorScheme(
     primary = GajaColors.Primary,
-    onPrimary = Color(0xFF111111),
+    onPrimary = GajaColors.White,
     primaryContainer = GajaColors.Carbon,
-    
-    background = Color(0xFF111111),
+
+    background = Color(0xFF18211B),
     onBackground = GajaColors.White,
-    
-    surface = Color(0xFF1C1C1E),
+
+    surface = Color(0xFF223028),
     onSurface = GajaColors.White,
-    
-    outline = Color(0xFF333333),
+
+    outline = Color(0xFF425247),
+)
+
+private val GajaFontFamily = FontFamily(
+    Font(R.font.pretendard_regular, FontWeight.Normal),
+    Font(R.font.pretendard_regular, FontWeight.Medium),
+    Font(R.font.pretendard_bold, FontWeight.SemiBold),
+    Font(R.font.pretendard_bold, FontWeight.Bold),
+    Font(R.font.pretendard_bold, FontWeight.ExtraBold),
 )
 
 private val GajaTypography = Typography(
     displayLarge = TextStyle(
-        fontWeight = FontWeight.Black,
-        fontSize = 36.sp,
-        letterSpacing = (-1).sp,
+        fontFamily = GajaFontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = 34.sp,
+        letterSpacing = (-0.8).sp,
         lineHeight = 42.sp,
         color = Color.Unspecified
     ),
     displayMedium = TextStyle(
-        fontWeight = FontWeight.ExtraBold,
+        fontFamily = GajaFontFamily,
+        fontWeight = FontWeight.Bold,
         fontSize = 28.sp,
-        letterSpacing = (-0.5).sp,
-        lineHeight = 34.sp,
+        letterSpacing = (-0.4).sp,
+        lineHeight = 36.sp,
         color = Color.Unspecified
     ),
     headlineLarge = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.Bold,
         fontSize = 24.sp,
-        letterSpacing = (-0.2).sp,
+        letterSpacing = (-0.3).sp,
         lineHeight = 32.sp,
         color = Color.Unspecified
     ),
     headlineMedium = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.Bold,
         fontSize = 20.sp,
+        letterSpacing = (-0.2).sp,
         lineHeight = 28.sp,
         color = Color.Unspecified
     ),
     headlineSmall = TextStyle(
-        fontWeight = FontWeight.Bold,
+        fontFamily = GajaFontFamily,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 18.sp,
-        lineHeight = 26.sp,
+        letterSpacing = (-0.1).sp,
+        lineHeight = 27.sp,
         color = Color.Unspecified
     ),
     titleLarge = TextStyle(
-        fontWeight = FontWeight.Bold,
+        fontFamily = GajaFontFamily,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 18.sp,
-        lineHeight = 24.sp,
+        letterSpacing = (-0.1).sp,
+        lineHeight = 26.sp,
         color = Color.Unspecified
     ),
     titleMedium = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.SemiBold,
         fontSize = 16.sp,
-        lineHeight = 22.sp,
+        lineHeight = 24.sp,
         color = Color.Unspecified
     ),
     titleSmall = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.SemiBold,
         fontSize = 14.sp,
-        lineHeight = 20.sp,
+        lineHeight = 21.sp,
         color = Color.Unspecified
     ),
     bodyLarge = TextStyle(
-        fontWeight = FontWeight.Medium,
+        fontFamily = GajaFontFamily,
+        fontWeight = FontWeight.Normal,
         fontSize = 15.sp,
-        lineHeight = 22.sp,
+        lineHeight = 24.sp,
         color = Color.Unspecified
     ),
     bodyMedium = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp,
-        lineHeight = 20.sp,
+        lineHeight = 22.sp,
         color = Color.Unspecified
     ),
     bodySmall = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 12.sp,
-        lineHeight = 18.sp,
+        lineHeight = 19.sp,
         color = Color.Unspecified
     ),
     labelLarge = TextStyle(
-        fontWeight = FontWeight.Bold,
+        fontFamily = GajaFontFamily,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 13.sp,
-        letterSpacing = 0.5.sp,
+        letterSpacing = 0.sp,
         color = Color.Unspecified
     ),
     labelMedium = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.SemiBold,
         fontSize = 12.sp,
-        letterSpacing = 0.3.sp,
+        letterSpacing = 0.sp,
         color = Color.Unspecified
     ),
     labelSmall = TextStyle(
+        fontFamily = GajaFontFamily,
         fontWeight = FontWeight.SemiBold,
         fontSize = 11.sp,
-        letterSpacing = 0.5.sp,
+        letterSpacing = 0.sp,
         color = Color.Unspecified
     )
 )
 
 private val GajaShapes = Shapes(
-    extraSmall = RoundedCornerShape(4.dp),
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(12.dp),
-    large = RoundedCornerShape(16.dp),
-    extraLarge = RoundedCornerShape(20.dp),
+    extraSmall = RoundedCornerShape(6.dp),
+    small = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(22.dp),
+    extraLarge = RoundedCornerShape(28.dp),
 )
 
 object GajaSpacing {
-    val ScreenPadding = 16.dp
+    val ScreenPadding = 20.dp
     val ItemSpacing = 16.dp
     val Large = 24.dp
     val Medium = 16.dp
     val Small = 12.dp
     val Tiny = 8.dp
     val Micro = 4.dp
-    val SectionGap = 24.dp
-    val CardPadding = 16.dp
+    val SectionGap = 28.dp
+    val CardPadding = 20.dp
     val CompactCardPadding = 12.dp
 }
 
 object GajaRadius {
     val Small = 12.dp
-    val Medium = 16.dp
-    val Large = 20.dp
-    val XLarge = 24.dp
+    val Medium = 18.dp
+    val Large = 24.dp
+    val XLarge = 28.dp
     val Pill = 999.dp
 }
 
@@ -226,10 +245,10 @@ object GajaIconSizes {
 }
 
 object GajaCardTokens {
-    val DefaultPadding = 16.dp
+    val DefaultPadding = 20.dp
     val CompactPadding = 12.dp
-    val HeroPadding = 20.dp
-    val ElevatedPadding = 18.dp
+    val HeroPadding = 24.dp
+    val ElevatedPadding = 20.dp
     val BorderWidth = 1.dp
     val SubtleElevation = 2.dp
 }

--- a/app/src/test/java/com/bikeprojectminji/bikefront/ui/screen/CoursesRepositoryMergeRecordedCoursesTest.kt
+++ b/app/src/test/java/com/bikeprojectminji/bikefront/ui/screen/CoursesRepositoryMergeRecordedCoursesTest.kt
@@ -1,6 +1,5 @@
 package com.bikeprojectminji.bikefront.ui.screen
 
-import com.bikeprojectminji.bikefront.course.RecordedCourseItem
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -10,13 +9,13 @@ class CoursesRepositoryMergeRecordedCoursesTest {
 
     @Test
     fun `merge marks only canonical items that also exist in recorded store`() {
+        val recordedItems = listOf(
+            com.bikeprojectminji.bikefront.course.RecordedCourseItem(id = 10L, title = "로컬 저장 코스", distanceKm = 11.0, estimatedDurationMin = 31),
+            com.bikeprojectminji.bikefront.course.RecordedCourseItem(id = 99L, title = "로컬 전용 코스", distanceKm = 5.0, estimatedDurationMin = 15),
+        )
         val items = listOf(
             CourseCardUiModel(id = 10L, title = "백엔드 코스", distanceKm = 10.0, estimatedDurationMin = 30),
             CourseCardUiModel(id = 20L, title = "다른 코스", distanceKm = 20.0, estimatedDurationMin = 50),
-        )
-        val recordedItems = listOf(
-            RecordedCourseItem(id = 10L, title = "로컬 저장 코스", distanceKm = 11.0, estimatedDurationMin = 31),
-            RecordedCourseItem(id = 99L, title = "로컬 전용 코스", distanceKm = 5.0, estimatedDurationMin = 15),
         )
 
         val merged = mergeRecordedCoursesWithCanonicalItems(items, recordedItems)


### PR DESCRIPTION
## Summary
- refresh the BIKE Android app entry, account, and pre-ride copy to a more service-like tone
- keep the course screen truthful by retaining the recommended/all structure and clarifying that the all tab shows public courses
- switch the debug API base URL default to https://api.gajabike.shop and keep tests aligned with the current course merge behavior

## Verification
- cmd.exe /c gradlew.bat assembleDebug --no-parallel --max-workers=1 --rerun-tasks
- cmd.exe /c gradlew.bat test --no-parallel --max-workers=1 --rerun-tasks
- adb reinstall and launch against the deployed backend, then confirm home/course data loads from the live API